### PR TITLE
ci: only use sccache if we have AWS credentials

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -53,7 +53,6 @@ jobs:
       SCCACHE_S3_USE_SSL: '1'
       # Prevent sccache server from stopping due to inactivity.
       SCCACHE_IDLE_TIMEOUT: '0'
-      RUSTC_WRAPPER: sccache
 
       # This forces the lzma-sys crate to link liblzma statically. Ideally we'd do
       # this with a crate feature. But the xz2 crate didn't expose that feature at the
@@ -66,6 +65,11 @@ jobs:
         with:
           rust_toolchain: stable
           rust_target: ${{ matrix.target.triple }}
+
+      - name: Activate sccache
+        if: github.repository == 'indygreg/apple-platform-rs'
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - uses: actions-rs/install@v0.1
         if: matrix.target.cross

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -46,24 +46,23 @@ jobs:
           rust_toolchain: ${{ matrix.rust_toolchain }}
           rust_target: ${{ matrix.target.triple }}
 
+      - name: Activate sccache
+        if: github.repository == 'indygreg/apple-platform-rs'
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
       - name: Build Workspace
-        env:
-          RUSTC_WRAPPER: sccache
         run: |
           rustc --version
           cargo build --workspace
           cargo nextest run --no-run --workspace
 
       - name: Test Workspace
-        env:
-          RUSTC_WRAPPER: sccache
         run: |
-          cargo nextest run --no-fail-fast --success-output immediate-final --workspace
+          cargo nextest run --no-fail-fast --workspace
 
       - uses: actions-rs/clippy@master
         if: ${{ matrix.rust_toolchain == 'stable' || matrix.rust_toolchain == 'beta' }}
-        env:
-          RUSTC_WRAPPER: sccache
         with:
           args: --workspace
 


### PR DESCRIPTION
Otherwise compiles from PRs will attempt to use it, hit timeouts, and will slow down considerably.