### PR TITLE
Fix smartcard-import certificate import command documentation

### DIFF
--- a/apple-codesign/docs/apple_codesign_smartcard.rst
+++ b/apple-codesign/docs/apple_codesign_smartcard.rst
@@ -154,6 +154,7 @@ Finally, import the Apple-issued public certificate into the smart card::
 
     rcodesign smartcard-import \
         --der-source developerID_application.cer \
+        --existing-key \
         --smartcard-slot 9c
 
 At this point, the smart card is ready to sign using an Apple issued certificate


### PR DESCRIPTION
Was missing `--existing-key`, which resulted in a `no private key found` error.