### PR TITLE
implement support for specifying smartcard PIN in an environment variable for signing operatons

### DIFF
--- a/apple-codesign/src/cli.rs
+++ b/apple-codesign/src/cli.rs
@@ -629,7 +629,7 @@ fn collect_certificates_from_args(
     if scan_smartcard {
         if let Some(slot) = args.get_one::<String>("smartcard_slot") {
             let pin_env_var = args.get_one::<String>("smartcard_pin_env");
-            handle_smartcard_sign_slot(slot, pin_env_var, &mut keys, &mut certs)?;
+            handle_smartcard_sign_slot(slot, pin_env_var.map(|x| &**x), &mut keys, &mut certs)?;
         }
     }
 
@@ -870,7 +870,7 @@ fn prompt_smartcard_pin() -> Result<Vec<u8>, AppleCodesignError> {
 #[cfg(feature = "yubikey")]
 fn handle_smartcard_sign_slot(
     slot: &str,
-    pin_env_var: Option<&String>,
+    pin_env_var: Option<&str>,
     private_keys: &mut Vec<Box<dyn PrivateKey>>,
     public_certificates: &mut Vec<CapturedX509Certificate>,
 ) -> Result<(), AppleCodesignError> {
@@ -883,7 +883,7 @@ fn handle_smartcard_sign_slot(
 
         yk.set_pin_callback(move || {
             if let Ok(pin) = std::env::var(&pin_var) {
-                eprintln!("using {} environment variable", &pin_var);
+                eprintln!("using PIN from {} environment variable", &pin_var);
                 Ok(pin.as_bytes().to_vec())
             } else {
                 prompt_smartcard_pin()
@@ -907,7 +907,7 @@ fn handle_smartcard_sign_slot(
 #[cfg(not(feature = "yubikey"))]
 fn handle_smartcard_sign_slot(
     _slot: &str,
-    _pin_env_var: Option<&String>,
+    _pin_env_var: Option<&str>,
     _private_keys: &mut [Box<dyn PrivateKey>],
     _public_certificates: &mut [CapturedX509Certificate],
 ) -> Result<(), AppleCodesignError> {

--- a/apple-codesign/src/yubikey.rs
+++ b/apple-codesign/src/yubikey.rs
@@ -183,9 +183,7 @@ impl YubiKey {
     }
 
     /// Set a callback function to be used for retrieving the PIN.
-    pub fn set_pin_callback<T>(&mut self, cb: T)
-        where T: PinCallback + 'static
-    {
+    pub fn set_pin_callback(&mut self, cb: impl PinCallback + 'static) {
         self.pin_callback = Some(Rc::new(cb));
     }
 


### PR DESCRIPTION
This PR implements a `--smartcard-pin-env` for specifying an environment variable which holds the smartcard PIN (in the same fashion as `--remote-shared-secret-env`). If this argument is not specified, or the environment variable is empty, the operation falls back to the existing interactive prompt.

I implemented this by changing `set_pin_callback()` to be able to take a closure rather than a function pointer, which required a bit of surgery in `yubikey.rs`. Happy to re-implement this a different way (for example, some sort of `PINSource` enum, with keyboard input and already-allocated PIN as options).

Notably missing from this PR:
- Support for operations other than signing.

    My intended usage for this was an HSM in a remote CI machine, so in a sense this fulfills the same sort of use-case as the remote signing support. I don't think that providing the PIN outside of keyboard input for management operations is a good idea from a security standpoint.

- A separate argument for specifying the PIN directly via a command line argument.

    Roughly the same equivalent to `--remote-shared-secret`. I have only slight reservations about implementing this (I'm very happy to discourage passing secrets as command line parameters) but would do so if you would prefer.

- Documentation.

    Happy to add once you're happy with the implementation. :)

Have tested and works well with a Yubikey 5.

Resolves #33 