### PR TITLE
Fix support for ADHOC app bundle signing with frameworks

### DIFF
--- a/apple-codesign/src/macho_signing.rs
+++ b/apple-codesign/src/macho_signing.rs
@@ -629,14 +629,14 @@ impl<'data> MachOSigner<'data> {
             }
         }
 
+        info!("code requirements: {}", requirements);
+        let mut blob = RequirementSetBlob::default();
+
         if !requirements.is_empty() {
-            info!("code requirements: {}", requirements);
-
-            let mut blob = RequirementSetBlob::default();
             requirements.add_to_requirement_set(&mut blob, RequirementType::Designated)?;
-
-            res.push((CodeSigningSlot::RequirementSet, blob.into()));
         }
+
+        res.push((CodeSigningSlot::RequirementSet, blob.into()));
 
         if let Some(entitlements) = settings.entitlements_xml(SettingsScope::Main)? {
             info!("adding entitlements XML");

--- a/apple-codesign/src/macho_signing.rs
+++ b/apple-codesign/src/macho_signing.rs
@@ -629,10 +629,10 @@ impl<'data> MachOSigner<'data> {
             }
         }
 
-        info!("code requirements: {}", requirements);
         let mut blob = RequirementSetBlob::default();
 
         if !requirements.is_empty() {
+            info!("code requirements: {}", requirements);
             requirements.add_to_requirement_set(&mut blob, RequirementType::Designated)?;
         }
 


### PR DESCRIPTION
Before this, codesign would error with "the sealed resource directory is invalid".

This add a new codepath when no code requirements has been set that will enforce a requirement presence and ensure that appropriate cdhashes are present for the given file.