### PR TITLE
apple-codesign: introduce trycmd for CLI testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "trycmd",
  "tungstenite",
  "uuid 1.2.1",
  "x509",
@@ -788,6 +789,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concolor"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90f9dcd9490a97db91a85ccd79e38a87e14323f0bb824659ee3274e9143ba37"
+dependencies = [
+ "atty",
+ "bitflags",
+ "concolor-query",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
+
+[[package]]
 name = "console"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +840,15 @@ name = "const-oid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cookie-factory"
@@ -1155,6 +1192,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dunce"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "ecdsa"
@@ -1544,6 +1587,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +1925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2020,16 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "os_pipe"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dceb7e43f59c35ee1548045b2c72945a5a3bb6ce6d6f07cdc13dc8f6bc4930a"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2740,6 +2809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2823,12 @@ dependencies = [
  "digest 0.10.5",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "similar"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "simple-file-manifest"
@@ -2803,6 +2884,34 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "snapbox"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827c00e91b15e2674d8a5270bae91f898693cbf9561cbb58d8eaa31974597293"
+dependencies = [
+ "concolor",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "libc",
+ "normalize-line-endings",
+ "os_pipe",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "wait-timeout",
+ "walkdir",
+ "winapi",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485e65c1203eb37244465e857d15a26d3a85a5410648ccb53b18bd44cb3a7336"
 
 [[package]]
 name = "socket2"
@@ -3062,6 +3171,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1541ba70885967e662f69d31ab3aeca7b1aaecfcd58679590b893e9239c3646"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "serde",
+ "toml_datetime",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,6 +3258,22 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "trycmd"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3e659433fd96381bbbd80a5d2a664e930444e222ea28e434fd4f6810525101"
+dependencies = [
+ "glob",
+ "humantime",
+ "humantime-serde",
+ "rayon",
+ "serde",
+ "shlex",
+ "snapbox",
+ "toml_edit",
+]
 
 [[package]]
 name = "tungstenite"
@@ -3247,6 +3394,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -3597,6 +3753,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/apple-codesign/Cargo.toml
+++ b/apple-codesign/Cargo.toml
@@ -98,6 +98,7 @@ security-framework = { version = "2.7", features = ["OSX_10_12"] }
 
 [dev-dependencies]
 indoc = "1.0"
+trycmd = "0.14.3"
 
 [features]
 default = []

--- a/apple-codesign/tests/cli_tests.rs
+++ b/apple-codesign/tests/cli_tests.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#[test]
+fn cli_tests() {
+    trycmd::TestCases::new()
+        .case("tests/cmd/*.trycmd")
+        .case("tests/cmd/*.toml");
+}

--- a/apple-codesign/tests/cmd/analyze-certificate.trycmd
+++ b/apple-codesign/tests/cmd/analyze-certificate.trycmd
@@ -1,0 +1,69 @@
+```
+$ rcodesign analyze-certificate --help
+Analyze an X.509 certificate for Apple code signing properties.
+
+Given the path to a PEM encoded X.509 certificate, this command will read
+the certificate and print information about it relevant to Apple code
+signing.
+
+The output of the command can be useful to learn about X.509 certificate
+extensions used by code signing certificates and to debug low-level
+properties related to certificates.
+
+
+Usage: rcodesign[EXE] analyze-certificate [OPTIONS]
+
+Options:
+      --smartcard-slot <smartcard_slot>
+          Smartcard slot number of signing certificate to use (9c is common)
+
+  -v, --verbose...
+          Increase logging verbosity. Can be specified multiple times.
+
+      --keychain-domain <keychain_domain>
+          (macOS only) Keychain domain to operate on
+          
+          [possible values: user, system, common, dynamic]
+
+      --keychain-fingerprint <keychain_fingerprint>
+          (macOS only) SHA-256 fingerprint of certificate in Keychain to use
+
+      --pem-source <pem_source>
+          Path to file containing PEM encoded certificate/key data
+
+      --der-source <der_source>
+          Path to file containing DER encoded certificate data
+
+      --p12-file <p12_path>
+          Path to a .p12/PFX file containing a certificate key pair
+
+      --p12-password <p12_password>
+          The password to use to open the --p12-file file
+
+      --p12-password-file <p12_password_file>
+          Path to file containing password for opening --p12-file file
+
+      --remote-signer
+          Send signing requests to a remote server
+
+      --remote-public-key <remote_public_key>
+          Base64 encoded public key data describing the signer
+
+      --remote-public-key-pem-file <remote_public_key_pem_file>
+          PEM encoded public key data describing the signer
+
+      --remote-shared-secret <remote_shared_secret>
+          Shared secret used for remote signing
+
+      --remote-shared-secret-env <remote_shared_secret_env>
+          Environment variable holding the shared secret used for remote signing
+
+      --remote-signing-url <remote_signing_url>
+          URL of a remote code signing server
+          
+          [default: wss://ws.codesign.gregoryszorc.com/]
+
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+```

--- a/apple-codesign/tests/cmd/generate-csr.trycmd
+++ b/apple-codesign/tests/cmd/generate-csr.trycmd
@@ -1,0 +1,43 @@
+```
+$ rcodesign generate-certificate-signing-request --help
+Generates a certificate signing request that can be sent to Apple and exchanged for a signing certificate
+
+Usage: rcodesign[EXE] generate-certificate-signing-request [OPTIONS]
+
+Options:
+      --csr-pem-path <csr_pem_path>
+          Path to file to write PEM encoded CSR to
+  -v, --verbose...
+          Increase logging verbosity. Can be specified multiple times.
+      --smartcard-slot <smartcard_slot>
+          Smartcard slot number of signing certificate to use (9c is common)
+      --keychain-domain <keychain_domain>
+          (macOS only) Keychain domain to operate on [possible values: user, system, common, dynamic]
+      --keychain-fingerprint <keychain_fingerprint>
+          (macOS only) SHA-256 fingerprint of certificate in Keychain to use
+      --pem-source <pem_source>
+          Path to file containing PEM encoded certificate/key data
+      --der-source <der_source>
+          Path to file containing DER encoded certificate data
+      --p12-file <p12_path>
+          Path to a .p12/PFX file containing a certificate key pair
+      --p12-password <p12_password>
+          The password to use to open the --p12-file file
+      --p12-password-file <p12_password_file>
+          Path to file containing password for opening --p12-file file
+      --remote-signer
+          Send signing requests to a remote server
+      --remote-public-key <remote_public_key>
+          Base64 encoded public key data describing the signer
+      --remote-public-key-pem-file <remote_public_key_pem_file>
+          PEM encoded public key data describing the signer
+      --remote-shared-secret <remote_shared_secret>
+          Shared secret used for remote signing
+      --remote-shared-secret-env <remote_shared_secret_env>
+          Environment variable holding the shared secret used for remote signing
+      --remote-signing-url <remote_signing_url>
+          URL of a remote code signing server [default: wss://ws.codesign.gregoryszorc.com/]
+  -h, --help
+          Print help information
+
+```

--- a/apple-codesign/tests/cmd/generate-self-signed-cert.trycmd
+++ b/apple-codesign/tests/cmd/generate-self-signed-cert.trycmd
@@ -1,0 +1,91 @@
+```
+$ rcodesign generate-self-signed-certificate --help
+Generate a self-signed certificate that can be used for code signing.
+
+This command will generate a new key pair using the algorithm of choice
+then create an X.509 certificate wrapper for it that is signed with the
+just-generated private key. The created X.509 certificate has extensions
+that mark it as appropriate for code signing.
+
+Certificates generated with this command can be useful for local testing.
+However, because it is a self-signed certificate and isn't signed by a
+trusted certificate authority, Apple operating systems may refuse to
+load binaries signed with it.
+
+By default the command prints 2 PEM encoded blocks. One block is for the
+X.509 public certificate. The other is for the PKCS#8 private key (which
+can include the public key).
+
+The `--pem-filename` argument can be specified to write the generated
+certificate pair to a pair of files. The destination files will have
+`.crt` and `.key` appended to the value provided.
+
+When the certificate is written to a file, it isn't printed to stdout.
+
+
+Usage: rcodesign[EXE] generate-self-signed-certificate [OPTIONS] --person-name <person_name>
+
+Options:
+      --algorithm <algorithm>
+          Which key type to use
+          
+          [default: ecdsa]
+          [possible values: ecdsa, ed25519]
+
+  -v, --verbose...
+          Increase logging verbosity. Can be specified multiple times.
+
+      --profile <profile>
+          [default: apple-development]
+          [possible values: mac-installer-distribution, apple-distribution, apple-development, developer-id-application, developer-id-installer]
+
+      --team-id <team_id>
+          Team ID (this is a short string attached to your Apple Developer account)
+          
+          [default: unset]
+
+      --person-name <person_name>
+          The name of the person this certificate is for
+
+      --country-name <country_name>
+          Country Name (C) value for certificate identifier
+          
+          [default: XX]
+
+      --validity-days <validity_days>
+          How many days the certificate should be valid for
+          
+          [default: 365]
+
+      --pem-filename <pem_filename>
+          Base name of files to write PEM encoded certificate to
+
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+```
+
+```
+$ rcodesign generate-self-signed-certificate --profile apple-development --person-name 'Johnny Apple'
+-----BEGIN CERTIFICATE-----
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+[..]
+-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+[..]
+[..]
+[..]
+-----END PRIVATE KEY-----
+
+```

--- a/apple-codesign/tests/cmd/help.trycmd
+++ b/apple-codesign/tests/cmd/help.trycmd
@@ -1,0 +1,70 @@
+```
+$ rcodesign
+? 2
+Sign and notarize Apple programs. See https://gregoryszorc.com/docs/apple-codesign/main/ for more docs.
+
+Usage: rcodesign[EXE] [OPTIONS] [COMMAND]
+
+Commands:
+  analyze-certificate                   Analyze an X.509 certificate for Apple code signing properties
+  compute-code-hashes                   Compute code hashes for a binary
+  diff-signatures                       Print a diff between the signature content of two paths
+  encode-app-store-connect-api-key      Encode App Store Connect API Key metadata to a single file
+  extract                               Extracts code signature data from a Mach-O binary
+  generate-certificate-signing-request  Generates a certificate signing request that can be sent to Apple and exchanged for a signing certificate
+  generate-self-signed-certificate      Generate a self-signed certificate for code signing
+  keychain-export-certificate-chain     Export Apple CA certificates from the macOS Keychain
+  keychain-print-certificates           Print information about certificates in the macOS keychain
+  notary-log                            Fetch the notarization log for a previous submission
+  notary-submit                         Upload an asset to Apple for notarization and possibly staple it
+  notary-wait                           Wait for completion of a previous submission
+  parse-code-signing-requirement        Parse binary Code Signing Requirement data into a human readable string
+  print-signature-info                  Print signature information for a filesystem path
+  remote-sign                           Create signatures initiated from a remote signing operation
+  sign                                  Sign a Mach-O binary or bundle
+  staple                                Staples a notarization ticket to an entity
+  verify                                Verifies code signature data
+  x509-oids                             Print information about X.509 OIDs related to Apple code signing
+  help                                  Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose...  Increase logging verbosity. Can be specified multiple times.
+  -h, --help        Print help information
+  -V, --version     Print version information
+
+```
+
+```
+$ rcodesign help
+Sign and notarize Apple programs. See https://gregoryszorc.com/docs/apple-codesign/main/ for more docs.
+
+Usage: rcodesign[EXE] [OPTIONS] [COMMAND]
+
+Commands:
+  analyze-certificate                   Analyze an X.509 certificate for Apple code signing properties
+  compute-code-hashes                   Compute code hashes for a binary
+  diff-signatures                       Print a diff between the signature content of two paths
+  encode-app-store-connect-api-key      Encode App Store Connect API Key metadata to a single file
+  extract                               Extracts code signature data from a Mach-O binary
+  generate-certificate-signing-request  Generates a certificate signing request that can be sent to Apple and exchanged for a signing certificate
+  generate-self-signed-certificate      Generate a self-signed certificate for code signing
+  keychain-export-certificate-chain     Export Apple CA certificates from the macOS Keychain
+  keychain-print-certificates           Print information about certificates in the macOS keychain
+  notary-log                            Fetch the notarization log for a previous submission
+  notary-submit                         Upload an asset to Apple for notarization and possibly staple it
+  notary-wait                           Wait for completion of a previous submission
+  parse-code-signing-requirement        Parse binary Code Signing Requirement data into a human readable string
+  print-signature-info                  Print signature information for a filesystem path
+  remote-sign                           Create signatures initiated from a remote signing operation
+  sign                                  Sign a Mach-O binary or bundle
+  staple                                Staples a notarization ticket to an entity
+  verify                                Verifies code signature data
+  x509-oids                             Print information about X.509 OIDs related to Apple code signing
+  help                                  Print this message or the help of the given subcommand(s)
+
+Options:
+  -v, --verbose...  Increase logging verbosity. Can be specified multiple times.
+  -h, --help        Print help information
+  -V, --version     Print version information
+
+```

--- a/apple-codesign/tests/cmd/x509-oids.trycmd
+++ b/apple-codesign/tests/cmd/x509-oids.trycmd
@@ -1,0 +1,42 @@
+```
+$ rcodesign x509-oids
+# Extended Key Usage (EKU) Extension OIDs
+
+1.3.6.1.5.5.7.3.3	CodeSigning
+1.2.840.113635.100.4.8	SafariDeveloper
+1.2.840.113635.100.4.9	ThirdPartyMacDeveloperInstaller
+1.2.840.113635.100.4.13	DeveloperIdInstaller
+
+# Code Signing Certificate Extension OIDs
+
+1.2.840.113635.100.6.1.1	AppleSigning
+1.2.840.113635.100.6.1.2	IPhoneDeveloper
+1.2.840.113635.100.6.1.3	IPhoneOsApplicationSigning
+1.2.840.113635.100.6.1.4	AppleDeveloperCertificateSubmission
+1.2.840.113635.100.6.1.5	SafariDeveloper
+1.2.840.113635.100.6.1.6	IPhoneOsVpnSigning
+1.2.840.113635.100.6.1.7	AppleMacAppSigningDevelopment
+1.2.840.113635.100.6.1.8	AppleMacAppSigningSubmission
+1.2.840.113635.100.6.1.9	AppleMacAppStoreCodeSigning
+1.2.840.113635.100.6.1.10	AppleMacAppStoreInstallerSigning
+1.2.840.113635.100.6.1.12	MacDeveloper
+1.2.840.113635.100.6.1.13	DeveloperIdApplication
+1.2.840.113635.100.6.1.33	DeveloperIdDate
+1.2.840.113635.100.6.1.14	DeveloperIdInstaller
+1.2.840.113635.100.6.1.16	ApplePayPassbookSigning
+1.2.840.113635.100.6.1.17	WebsitePushNotificationSigning
+1.2.840.113635.100.6.1.18	DeveloperIdKernel
+1.2.840.113635.100.6.1.25.1	TestFlight
+
+# Certificate Authority Certificate Extension OIDs
+
+1.2.840.113635.100.6.2.1	AppleWorldwideDeveloperRelations
+1.2.840.113635.100.6.2.3	AppleApplicationIntegration
+1.2.840.113635.100.6.2.6	DeveloperId
+1.2.840.113635.100.6.2.9	AppleTimestamp
+1.2.840.113635.100.6.2.11	DeveloperAuthentication
+1.2.840.113635.100.6.2.14	AppleApplicationIntegrationG3
+1.2.840.113635.100.6.2.15	AppleWorldwideDeveloperRelationsG2
+1.2.840.113635.100.6.2.19	AppleSoftwareUpdateCertification
+
+```


### PR DESCRIPTION
We don't have great test coverage of the CLI. Let's introduce `trycmd` so we can start to change that.