### PR TITLE
ci: only trigger on pushes to main

### DIFF
--- a/.github/workflows/rcodesign.yml
+++ b/.github/workflows/rcodesign.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - 'ci-test'
+    branches:
+      - main
     tags-ignore:
       - '**'
   pull_request:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - 'ci-test'
+    branches:
+      - main
     tags-ignore:
       - '**'
   pull_request:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    branches-ignore:
-      - 'ci-test'
+    branches:
+      - main
     tags-ignore:
       - '**'
   pull_request:


### PR DESCRIPTION
Before this, CI would run for both a branch push and a PR event. That resulted in double CI for project maintainers.

Let's just trigger CI on the main branch and on PRs. This could inconvenience people who push branches to this repo. But what else can you do?