### PR TITLE
Appstoreconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
+name = "app-store-connect"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.20.0",
+ "clap",
+ "dirs",
+ "env_logger",
+ "jsonwebtoken",
+ "log",
+ "pem",
+ "rand",
+ "reqwest",
+ "rsa",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "x509-certificate 0.15.0",
+]
+
+[[package]]
 name = "apple-bom"
 version = "0.1.0-pre"
 dependencies = [
@@ -61,6 +82,7 @@ name = "apple-codesign"
 version = "0.22.0-pre"
 dependencies = [
  "anyhow",
+ "app-store-connect",
  "apple-bundles",
  "apple-flat-package",
  "apple-xar",
@@ -124,7 +146,7 @@ dependencies = [
  "tungstenite",
  "uuid 1.2.2",
  "x509",
- "x509-certificate",
+ "x509-certificate 0.16.0",
  "xml-rs",
  "yasna",
  "yubikey",
@@ -196,7 +218,7 @@ dependencies = [
  "signature",
  "thiserror",
  "url",
- "x509-certificate",
+ "x509-certificate 0.16.0",
  "xml-rs",
  "xz2",
 ]
@@ -772,10 +794,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "is-terminal",
+ "once_cell",
  "strsim",
  "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1000,7 +1037,7 @@ dependencies = [
  "reqwest",
  "ring",
  "signature",
- "x509-certificate",
+ "x509-certificate 0.16.0",
 ]
 
 [[package]]
@@ -2260,6 +2297,30 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -3682,6 +3743,24 @@ checksum = "ca3cec94c3999f31341553f358ef55f65fc031291a022cd42ec0ce7219560c76"
 dependencies = [
  "chrono",
  "cookie-factory",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22d96cc26820ae985ec042be273c52f1661bcfc26e13a55957faf3a433577"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     'apple-flat-package',
     'apple-sdk',
     'apple-xar',
+    'app-store-connect',
     'cpio-archive',
 ]
 resolver = "2"

--- a/app-store-connect/Cargo.toml
+++ b/app-store-connect/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "app-store-connect"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.68"
+base64 = "0.20.0"
+clap = { version = "4.0.29", features = ["derive"] }
+dirs = "4.0.0"
+env_logger = "0.10.0"
+jsonwebtoken = "8.2.0"
+log = "0.4.17"
+pem = "1.1.0"
+rand = "0.8.5"
+reqwest = { version = "0.11.13", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+rsa = "0.7.2"
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = "1.0.89"
+thiserror = "1.0.38"
+x509-certificate = "0.15.0"

--- a/app-store-connect/Cargo.toml
+++ b/app-store-connect/Cargo.toml
@@ -2,6 +2,7 @@
 name = "app-store-connect"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0 OR MIT"
 
 [dependencies]
 anyhow = "1.0.68"

--- a/app-store-connect/src/api_key.rs
+++ b/app-store-connect/src/api_key.rs
@@ -1,6 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 //! API Key
 

--- a/app-store-connect/src/api_token.rs
+++ b/app-store-connect/src/api_token.rs
@@ -5,10 +5,11 @@
 //! App Store Connect API tokens.
 
 use {
-    crate::AppleCodesignError,
+    crate::Result,
     jsonwebtoken::{Algorithm, EncodingKey, Header},
     serde::{Deserialize, Serialize},
     std::{path::Path, time::SystemTime},
+    thiserror::Error,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -62,22 +63,14 @@ impl ConnectTokenEncoder {
     }
 
     /// Construct an instance from a DER encoded ECDSA private key.
-    pub fn from_ecdsa_der(
-        key_id: String,
-        issuer_id: String,
-        der_data: &[u8],
-    ) -> Result<Self, AppleCodesignError> {
+    pub fn from_ecdsa_der(key_id: String, issuer_id: String, der_data: &[u8]) -> Result<Self> {
         let encoding_key = EncodingKey::from_ec_der(der_data);
 
         Ok(Self::from_jwt_encoding_key(key_id, issuer_id, encoding_key))
     }
 
     /// Create a token from a PEM encoded ECDSA private key.
-    pub fn from_ecdsa_pem(
-        key_id: String,
-        issuer_id: String,
-        pem_data: &[u8],
-    ) -> Result<Self, AppleCodesignError> {
+    pub fn from_ecdsa_pem(key_id: String, issuer_id: String, pem_data: &[u8]) -> Result<Self> {
         let encoding_key = EncodingKey::from_ec_pem(pem_data)?;
 
         Ok(Self::from_jwt_encoding_key(key_id, issuer_id, encoding_key))
@@ -88,7 +81,7 @@ impl ConnectTokenEncoder {
         key_id: String,
         issuer_id: String,
         path: impl AsRef<Path>,
-    ) -> Result<Self, AppleCodesignError> {
+    ) -> Result<Self> {
         let data = std::fs::read(path.as_ref())?;
 
         Self::from_ecdsa_pem(key_id, issuer_id, &data)
@@ -98,7 +91,7 @@ impl ConnectTokenEncoder {
     ///
     /// e.g. `DEADBEEF42`. This looks for an `AuthKey_<id>.p8` file in default search
     /// locations like `~/.appstoreconnect/private_keys`.
-    pub fn from_api_key_id(key_id: String, issuer_id: String) -> Result<Self, AppleCodesignError> {
+    pub fn from_api_key_id(key_id: String, issuer_id: String) -> Result<Self> {
         let mut search_paths = vec![std::env::current_dir()?.join("private_keys")];
 
         if let Some(home) = dirs::home_dir() {
@@ -120,14 +113,14 @@ impl ConnectTokenEncoder {
             }
         }
 
-        Err(AppleCodesignError::AppStoreConnectApiKeyNotFound)
+        Err(MissingApiKey.into())
     }
 
     /// Mint a new JWT token.
     ///
     /// Using the private key and key metadata bound to this instance, we issue a new JWT
     /// for the requested duration.
-    pub fn new_token(&self, duration: u64) -> Result<AppStoreConnectToken, AppleCodesignError> {
+    pub fn new_token(&self, duration: u64) -> Result<AppStoreConnectToken> {
         let header = Header {
             kid: Some(self.key_id.clone()),
             alg: Algorithm::ES256,
@@ -151,3 +144,7 @@ impl ConnectTokenEncoder {
         Ok(token)
     }
 }
+
+#[derive(Clone, Copy, Debug, Error)]
+#[error("no app store connect api key found")]
+pub struct MissingApiKey;

--- a/app-store-connect/src/api_token.rs
+++ b/app-store-connect/src/api_token.rs
@@ -1,6 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 //! App Store Connect API tokens.
 

--- a/app-store-connect/src/bundle_api.rs
+++ b/app-store-connect/src/bundle_api.rs
@@ -1,7 +1,13 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use crate::{AppStoreConnectClient, Result};
 use serde::{Deserialize, Serialize};
 
-const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/bundleIds";
+const APPLE_CERTIFICATE_URL: &str = "https://api.appstoreconnect.apple.com/v1/bundleIds";
 
 impl AppStoreConnectClient {
     pub fn register_bundle_id(&self, identifier: &str, name: &str) -> Result<BundleIdResponse> {

--- a/app-store-connect/src/bundle_api.rs
+++ b/app-store-connect/src/bundle_api.rs
@@ -1,0 +1,123 @@
+use crate::{AppStoreConnectClient, Result};
+use serde::{Deserialize, Serialize};
+
+const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/bundleIds";
+
+impl AppStoreConnectClient {
+    pub fn register_bundle_id(&self, identifier: &str, name: &str) -> Result<BundleIdResponse> {
+        let token = self.get_token()?;
+        let body = BundleIdCreateRequest {
+            data: BundleIdCreateRequestData {
+                attributes: BundleIdCreateRequestAttributes {
+                    identifier: identifier.into(),
+                    name: name.into(),
+                    platform: "UNIVERSAL".into(),
+                },
+                r#type: "bundleIds".into(),
+            },
+        };
+        let req = self
+            .client
+            .post(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .json(&body);
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn list_bundle_ids(&self) -> Result<BundleIdsResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn get_bundle_id(&self, id: &str) -> Result<BundleIdResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(format!("{}/{}", APPLE_CERTIFICATE_URL, id))
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn delete_bundle_id(&self, id: &str) -> Result<()> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .delete(format!("{}/{}", APPLE_CERTIFICATE_URL, id))
+            .bearer_auth(token);
+        self.send_request(req)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleIdCreateRequest {
+    pub data: BundleIdCreateRequestData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleIdCreateRequestData {
+    pub attributes: BundleIdCreateRequestAttributes,
+    pub r#type: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleIdCreateRequestAttributes {
+    pub identifier: String,
+    pub name: String,
+    pub platform: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BundleIdPlatform {
+    Ios,
+    MacOs,
+}
+
+impl std::fmt::Display for BundleIdPlatform {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s = match self {
+            Self::Ios => "IOS",
+            Self::MacOs => "MAC_OS",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleIdResponse {
+    pub data: BundleId,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleIdsResponse {
+    pub data: Vec<BundleId>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleId {
+    pub attributes: BundleIdAttributes,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BundleIdAttributes {
+    pub identifier: String,
+    pub name: String,
+    pub platform: String,
+    pub seed_id: String,
+}

--- a/app-store-connect/src/bundle_api.rs
+++ b/app-store-connect/src/bundle_api.rs
@@ -84,7 +84,7 @@ pub struct BundleIdCreateRequestAttributes {
     pub platform: String,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
 pub enum BundleIdPlatform {
     Ios,
     MacOs,

--- a/app-store-connect/src/certs_api.rs
+++ b/app-store-connect/src/certs_api.rs
@@ -1,3 +1,9 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use crate::{AppStoreConnectClient, Result};
 use rand::rngs::OsRng;
 use rsa::pkcs8::{EncodePrivateKey, LineEnding};
@@ -26,7 +32,7 @@ pub fn generate_key(api_key: &Path, ty: CertificateType, pem: &Path) -> Result<(
         .certificate_content;
     let cer = pem::encode(&pem::Pem {
         tag: "CERTIFICATE".into(),
-        contents: base64::decode(&cer)?,
+        contents: base64::decode(cer)?,
     });
     let mut f = File::create(pem)?;
     f.write_all(secret.to_pkcs8_pem(LineEnding::CRLF)?.as_bytes())?;
@@ -34,7 +40,7 @@ pub fn generate_key(api_key: &Path, ty: CertificateType, pem: &Path) -> Result<(
     Ok(())
 }
 
-const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/certificates";
+const APPLE_CERTIFICATE_URL: &str = "https://api.appstoreconnect.apple.com/v1/certificates";
 
 impl AppStoreConnectClient {
     pub fn create_certificate(

--- a/app-store-connect/src/certs_api.rs
+++ b/app-store-connect/src/certs_api.rs
@@ -1,0 +1,163 @@
+use crate::{AppStoreConnectClient, Result};
+use rand::rngs::OsRng;
+use rsa::pkcs8::{EncodePrivateKey, LineEnding};
+use rsa::RsaPrivateKey;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use x509_certificate::{InMemorySigningKeyPair, Sign, X509CertificateBuilder};
+
+pub fn generate_key(api_key: &Path, ty: CertificateType, pem: &Path) -> Result<()> {
+    let secret = RsaPrivateKey::new(&mut OsRng, 2048)?;
+    let key = InMemorySigningKeyPair::from_pkcs8_der(secret.to_pkcs8_der()?.as_bytes())?;
+    let mut builder = X509CertificateBuilder::new(key.key_algorithm().unwrap());
+    builder
+        .subject()
+        .append_common_name_utf8_string("Apple Code Signing CSR")
+        .expect("only valid chars");
+    let csr = builder
+        .create_certificate_signing_request(&key)?
+        .encode_pem()?;
+    let cer = AppStoreConnectClient::from_json_path(api_key)?
+        .create_certificate(csr, ty)?
+        .data
+        .attributes
+        .certificate_content;
+    let cer = pem::encode(&pem::Pem {
+        tag: "CERTIFICATE".into(),
+        contents: base64::decode(&cer)?,
+    });
+    let mut f = File::create(pem)?;
+    f.write_all(secret.to_pkcs8_pem(LineEnding::CRLF)?.as_bytes())?;
+    f.write_all(cer.as_bytes())?;
+    Ok(())
+}
+
+const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/certificates";
+
+impl AppStoreConnectClient {
+    pub fn create_certificate(
+        &self,
+        csr: String,
+        ty: CertificateType,
+    ) -> Result<CertificateResponse> {
+        let token = self.get_token()?;
+        let body = CertificateCreateRequest {
+            data: CertificateCreateRequestData {
+                attributes: CertificateCreateRequestAttributes {
+                    certificate_type: ty.to_string(),
+                    csr_content: csr,
+                },
+                r#type: "certificates".into(),
+            },
+        };
+        let req = self
+            .client
+            .post(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .json(&body);
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn list_certificates(&self) -> Result<CertificatesResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn get_certificate(&self, id: &str) -> Result<CertificateResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(format!("{}/{}", APPLE_CERTIFICATE_URL, id))
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn revoke_certificate(&self, id: &str) -> Result<()> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .delete(format!("{}/{}", APPLE_CERTIFICATE_URL, id))
+            .bearer_auth(token);
+        self.send_request(req)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CertificateCreateRequest {
+    pub data: CertificateCreateRequestData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CertificateCreateRequestData {
+    pub attributes: CertificateCreateRequestAttributes,
+    pub r#type: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CertificateCreateRequestAttributes {
+    pub certificate_type: String,
+    pub csr_content: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CertificateType {
+    Development,
+    Distribution,
+    DeveloperIdApplication,
+}
+
+impl std::fmt::Display for CertificateType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s = match self {
+            Self::Development => "DEVELOPMENT",
+            Self::Distribution => "DISTRIBUTION",
+            Self::DeveloperIdApplication => "DEVELOPER_ID_APPLICATION",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CertificateResponse {
+    pub data: Certificate,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CertificatesResponse {
+    pub data: Vec<Certificate>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Certificate {
+    pub attributes: CertificateAttributes,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CertificateAttributes {
+    pub certificate_content: String,
+    pub display_name: String,
+    pub expiration_date: String,
+    pub name: String,
+    pub platform: Option<String>,
+    pub serial_number: String,
+    pub certificate_type: String,
+}

--- a/app-store-connect/src/certs_api.rs
+++ b/app-store-connect/src/certs_api.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::path::Path;
 use x509_certificate::{InMemorySigningKeyPair, Sign, X509CertificateBuilder};
 
-pub fn generate_key(api_key: &Path, ty: CertificateType, pem: &Path) -> Result<()> {
+pub fn generate_signing_certificate(api_key: &Path, ty: CertificateType, pem: &Path) -> Result<()> {
     let secret = RsaPrivateKey::new(&mut OsRng, 2048)?;
     let key = InMemorySigningKeyPair::from_pkcs8_der(secret.to_pkcs8_der()?.as_bytes())?;
     let mut builder = X509CertificateBuilder::new(key.key_algorithm().unwrap());
@@ -119,7 +119,7 @@ pub struct CertificateCreateRequestAttributes {
     pub csr_content: String,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
 pub enum CertificateType {
     Development,
     Distribution,

--- a/app-store-connect/src/device_api.rs
+++ b/app-store-connect/src/device_api.rs
@@ -1,8 +1,14 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use crate::bundle_api::BundleIdPlatform;
 use crate::{AppStoreConnectClient, Result};
 use serde::{Deserialize, Serialize};
 
-const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/devices";
+const APPLE_CERTIFICATE_URL: &str = "https://api.appstoreconnect.apple.com/v1/devices";
 
 impl AppStoreConnectClient {
     pub fn register_device(

--- a/app-store-connect/src/device_api.rs
+++ b/app-store-connect/src/device_api.rs
@@ -1,0 +1,106 @@
+use crate::bundle_api::BundleIdPlatform;
+use crate::{AppStoreConnectClient, Result};
+use serde::{Deserialize, Serialize};
+
+const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/devices";
+
+impl AppStoreConnectClient {
+    pub fn register_device(
+        &self,
+        name: &str,
+        platform: BundleIdPlatform,
+        udid: &str,
+    ) -> Result<DeviceResponse> {
+        let token = self.get_token()?;
+        let body = DeviceCreateRequest {
+            data: DeviceCreateRequestData {
+                attributes: DeviceCreateRequestAttributes {
+                    name: name.into(),
+                    platform: platform.to_string(),
+                    udid: udid.into(),
+                },
+                r#type: "devices".into(),
+            },
+        };
+        let req = self
+            .client
+            .post(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .json(&body);
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn list_devices(&self) -> Result<DevicesResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn get_device(&self, id: &str) -> Result<DeviceResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(format!("{}/{}", APPLE_CERTIFICATE_URL, id))
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceCreateRequest {
+    pub data: DeviceCreateRequestData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceCreateRequestData {
+    pub attributes: DeviceCreateRequestAttributes,
+    pub r#type: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceCreateRequestAttributes {
+    pub name: String,
+    pub platform: String,
+    pub udid: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceResponse {
+    pub data: Device,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DevicesResponse {
+    pub data: Vec<Device>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Device {
+    pub attributes: DeviceAttributes,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceAttributes {
+    pub device_class: String,
+    pub model: Option<String>,
+    pub name: String,
+    pub platform: String,
+    pub status: String,
+    pub udid: String,
+    pub added_date: String,
+}

--- a/app-store-connect/src/lib.rs
+++ b/app-store-connect/src/lib.rs
@@ -1,6 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 mod api_key;
 mod api_token;
@@ -80,12 +82,12 @@ impl AppStoreConnectClient {
                 String::from_utf8_lossy(body.as_ref()).into()
             };
 
-            return Err(AppStoreConnectError {
+            Err(AppStoreConnectError {
                 method,
                 url,
                 message,
             }
-            .into());
+            .into())
         }
     }
 }

--- a/app-store-connect/src/lib.rs
+++ b/app-store-connect/src/lib.rs
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+mod api_key;
+mod api_token;
+pub mod bundle_api;
+pub mod certs_api;
+pub mod device_api;
+pub mod notary_api;
+pub mod profile_api;
+
+use {
+    reqwest::blocking::{Client, ClientBuilder, RequestBuilder, Response},
+    serde_json::Value,
+    std::{path::Path, sync::Mutex},
+    thiserror::Error,
+};
+
+pub use crate::api_key::{InvalidPemPrivateKey, UnifiedApiKey};
+pub use crate::api_token::{AppStoreConnectToken, ConnectTokenEncoder, MissingApiKey};
+
+pub type Result<T> = anyhow::Result<T>;
+
+/// A client for App Store Connect API.
+///
+/// The client isn't generic. Don't get any ideas.
+pub struct AppStoreConnectClient {
+    client: Client,
+    connect_token: ConnectTokenEncoder,
+    token: Mutex<Option<AppStoreConnectToken>>,
+}
+
+impl AppStoreConnectClient {
+    pub fn from_json_path(path: &Path) -> Result<Self> {
+        let key = UnifiedApiKey::from_json_path(path)?;
+        AppStoreConnectClient::new(key.try_into()?)
+    }
+
+    /// Create a new client to the App Store Connect API.
+    pub fn new(connect_token: ConnectTokenEncoder) -> Result<Self> {
+        let client = ClientBuilder::default()
+            .user_agent("asconnect crate (https://crates.io/crates/asconnect)")
+            .build()?;
+        Ok(Self {
+            client,
+            connect_token,
+            token: Mutex::new(None),
+        })
+    }
+
+    pub fn get_token(&self) -> Result<String> {
+        let mut token = self.token.lock().unwrap();
+
+        // TODO need to handle token expiration.
+        if token.is_none() {
+            token.replace(self.connect_token.new_token(300)?);
+        }
+
+        Ok(token.as_ref().unwrap().clone())
+    }
+
+    pub fn send_request(&self, request: RequestBuilder) -> Result<Response> {
+        let request = request.build()?;
+        let method = request.method().to_string();
+        let url = request.url().to_string();
+
+        log::debug!("{} {}", request.method(), url);
+
+        let response = self.client.execute(request)?;
+
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            let body = response.bytes()?;
+
+            let message = if let Ok(value) = serde_json::from_slice::<Value>(body.as_ref()) {
+                serde_json::to_string_pretty(&value)?
+            } else {
+                String::from_utf8_lossy(body.as_ref()).into()
+            };
+
+            return Err(AppStoreConnectError {
+                method,
+                url,
+                message,
+            }
+            .into());
+        }
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+#[error("appstore connect error:\n{method} {url}\n{message}")]
+pub struct AppStoreConnectError {
+    method: String,
+    url: String,
+    message: String,
+}

--- a/app-store-connect/src/main.rs
+++ b/app-store-connect/src/main.rs
@@ -1,0 +1,469 @@
+use anyhow::Result;
+use app_store_connect::bundle_api::{BundleId, BundleIdPlatform};
+use app_store_connect::certs_api::{self, Certificate, CertificateType};
+use app_store_connect::device_api::Device;
+use app_store_connect::profile_api::{Profile, ProfileType};
+use app_store_connect::{AppStoreConnectClient, UnifiedApiKey};
+use clap::{Parser, Subcommand};
+use std::io::Write;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+    let args = Args::parse();
+    args.command.run()
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generates a PEM encoded RSA2048 signing key
+    GenerateKey {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Certificate type can be one of development, distribution or notarization.
+        #[clap(long)]
+        r#type: String,
+        /// Path to write a new PEM encoded RSA2048 signing key
+        pem: PathBuf,
+    },
+    /// Creates a unified api key.
+    CreateApiKey {
+        /// Issuer id.
+        #[clap(long)]
+        issuer_id: String,
+        /// Key id.
+        #[clap(long)]
+        key_id: String,
+        /// Path to private key.
+        private_key: PathBuf,
+        /// Path to write a unified api key.
+        api_key: PathBuf,
+    },
+    Bundle {
+        #[clap(subcommand)]
+        command: BundleCommand,
+    },
+    Certificate {
+        #[clap(subcommand)]
+        command: CertificateCommand,
+    },
+    Device {
+        #[clap(subcommand)]
+        command: DeviceCommand,
+    },
+    Profile {
+        #[clap(subcommand)]
+        command: ProfileCommand,
+    },
+}
+
+impl Commands {
+    fn run(self) -> Result<()> {
+        match self {
+            Self::GenerateKey {
+                api_key,
+                r#type,
+                pem,
+            } => {
+                let r#type = parse_certificate_type(&r#type)?;
+                certs_api::generate_key(&api_key, r#type, &pem)?;
+            }
+            Self::CreateApiKey {
+                issuer_id,
+                key_id,
+                private_key,
+                api_key,
+            } => {
+                UnifiedApiKey::from_ecdsa_pem_path(issuer_id, key_id, private_key)?
+                    .write_json_file(api_key)?;
+            }
+            Self::Bundle { command } => command.run()?,
+            Self::Certificate { command } => command.run()?,
+            Self::Device { command } => command.run()?,
+            Self::Profile { command } => command.run()?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Subcommand)]
+enum BundleCommand {
+    Register {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Bundle identifier.
+        #[clap(long)]
+        identifier: String,
+        /// Bundle name.
+        #[clap(long)]
+        name: String,
+    },
+    List {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+    },
+    Get {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Id of certificate.
+        id: String,
+    },
+    Delete {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Id of bundle id to revoke.
+        id: String,
+    },
+}
+
+impl BundleCommand {
+    fn run(self) -> Result<()> {
+        match self {
+            Self::Register {
+                api_key,
+                identifier,
+                name,
+            } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?
+                    .register_bundle_id(&identifier, &name)?;
+                print_bundle_id_header();
+                print_bundle_id(&resp.data);
+            }
+            Self::List { api_key } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.list_bundle_ids()?;
+                print_bundle_id_header();
+                for bundle_id in &resp.data {
+                    print_bundle_id(bundle_id);
+                }
+            }
+            Self::Get { api_key, id } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.get_bundle_id(&id)?;
+                print_bundle_id_header();
+                print_bundle_id(&resp.data);
+            }
+            Self::Delete { api_key, id } => {
+                AppStoreConnectClient::from_json_path(&api_key)?.delete_bundle_id(&id)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn parse_bundle_id_platform(s: &str) -> Result<BundleIdPlatform> {
+    Ok(match s {
+        "ios" => BundleIdPlatform::Ios,
+        "macos" => BundleIdPlatform::MacOs,
+        _ => anyhow::bail!("unsupported bundle id platform {}", s),
+    })
+}
+
+fn print_bundle_id_header() {
+    println!("{: <10} | {: <20} | {: <30}", "id", "name", "identifier");
+}
+
+fn print_bundle_id(bundle_id: &BundleId) {
+    println!(
+        "{: <10} | {: <20} | {: <30}",
+        bundle_id.id, bundle_id.attributes.name, bundle_id.attributes.identifier,
+    );
+}
+
+#[derive(Subcommand)]
+enum CertificateCommand {
+    Create {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Certificate type can be one of development, distribution or notarization.
+        #[clap(long)]
+        r#type: String,
+        /// Path to certificate signing request.
+        csr: PathBuf,
+    },
+    List {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+    },
+    Get {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Id of certificate.
+        id: String,
+    },
+    Revoke {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Id of certificate to revoke.
+        id: String,
+    },
+}
+
+impl CertificateCommand {
+    fn run(self) -> Result<()> {
+        match self {
+            Self::Create {
+                api_key,
+                csr,
+                r#type,
+            } => {
+                let r#type = parse_certificate_type(&r#type)?;
+                let csr = std::fs::read_to_string(csr)?;
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?
+                    .create_certificate(csr, r#type)?;
+                print_certificate_header();
+                print_certificate(&resp.data);
+            }
+            Self::List { api_key } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.list_certificates()?;
+                print_certificate_header();
+                for cert in &resp.data {
+                    print_certificate(cert);
+                }
+            }
+            Self::Get { api_key, id } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.get_certificate(&id)?;
+                let cer = pem::encode(&pem::Pem {
+                    tag: "CERTIFICATE".into(),
+                    contents: base64::decode(&resp.data.attributes.certificate_content)?,
+                });
+                println!("{}", cer);
+            }
+            Self::Revoke { api_key, id } => {
+                AppStoreConnectClient::from_json_path(&api_key)?.revoke_certificate(&id)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn parse_certificate_type(s: &str) -> Result<CertificateType> {
+    Ok(match s {
+        "development" => CertificateType::Development,
+        "distribution" => CertificateType::Distribution,
+        "notarization" => CertificateType::DeveloperIdApplication,
+        _ => anyhow::bail!("unsupported certificate type {}", s),
+    })
+}
+
+fn print_certificate_header() {
+    println!(
+        "{: <10} | {: <50} | {: <20}",
+        "id", "name", "expiration date"
+    );
+}
+
+fn print_certificate(cert: &Certificate) {
+    let expiration_date = cert.attributes.expiration_date.split_once('T').unwrap().0;
+    println!(
+        "{: <10} | {: <50} | {: <10}",
+        cert.id, cert.attributes.name, expiration_date
+    );
+}
+
+#[derive(Subcommand)]
+enum DeviceCommand {
+    Register {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Name for device.
+        #[clap(long)]
+        name: String,
+        /// Platform.
+        #[clap(long)]
+        platform: String,
+        /// Unique Device Identifier
+        #[clap(long)]
+        udid: String,
+    },
+    List {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+    },
+    Get {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Id of device.
+        id: String,
+    },
+}
+
+impl DeviceCommand {
+    fn run(self) -> Result<()> {
+        match self {
+            Self::Register {
+                api_key,
+                name,
+                platform,
+                udid,
+            } => {
+                let platform = parse_bundle_id_platform(&platform)?;
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?
+                    .register_device(&name, platform, &udid)?;
+                print_device_header();
+                print_device(&resp.data);
+            }
+            Self::List { api_key } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.list_devices()?;
+                print_device_header();
+                for device in &resp.data {
+                    print_device(device);
+                }
+            }
+            Self::Get { api_key, id } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.get_device(&id)?;
+                print_device_header();
+                print_device(&resp.data);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn print_device_header() {
+    println!(
+        "{: <10} | {: <20} | {: <20} | {: <20}",
+        "id", "name", "model", "udid"
+    );
+}
+
+fn print_device(device: &Device) {
+    let model = device.attributes.model.as_deref().unwrap_or_default();
+    println!(
+        "{: <10} | {: <20} | {: <20} | {: <20}",
+        device.id, device.attributes.name, model, device.attributes.udid,
+    );
+}
+
+#[derive(Subcommand)]
+enum ProfileCommand {
+    Create {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Name for profile.
+        #[clap(long)]
+        name: String,
+        /// Profile type.
+        #[clap(long)]
+        profile_type: String,
+        /// Bundle identifier id.
+        #[clap(long)]
+        bundle_id: String,
+        /// Certificate ids.
+        #[clap(long)]
+        certificate: Vec<String>,
+        /// Device ids.
+        #[clap(long)]
+        device: Option<Vec<String>>,
+    },
+    List {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+    },
+    Get {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Id of device.
+        id: String,
+    },
+    Delete {
+        /// Path to unified api key.
+        #[clap(long)]
+        api_key: PathBuf,
+        /// Id of device.
+        id: String,
+    },
+}
+
+impl ProfileCommand {
+    fn run(self) -> Result<()> {
+        match self {
+            Self::Create {
+                api_key,
+                name,
+                profile_type,
+                bundle_id,
+                certificate,
+                device,
+            } => {
+                let profile_type = parse_profile_type(&profile_type)?;
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.create_profile(
+                    &name,
+                    profile_type,
+                    &bundle_id,
+                    &certificate,
+                    device.as_deref(),
+                )?;
+                print_profile_header();
+                print_profile(&resp.data);
+            }
+            Self::List { api_key } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.list_profiles()?;
+                print_profile_header();
+                for profile in &resp.data {
+                    print_profile(profile);
+                }
+            }
+            Self::Get { api_key, id } => {
+                let resp = AppStoreConnectClient::from_json_path(&api_key)?.get_profile(&id)?;
+                let profile = base64::decode(&resp.data.attributes.profile_content)?;
+                std::io::stdout().write_all(&profile)?;
+            }
+            Self::Delete { api_key, id } => {
+                AppStoreConnectClient::from_json_path(&api_key)?.delete_profile(&id)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn parse_profile_type(s: &str) -> Result<ProfileType> {
+    Ok(match s {
+        "ios-dev" => ProfileType::IosAppDevelopment,
+        "macos-dev" => ProfileType::MacAppDevelopment,
+        "ios-appstore" => ProfileType::IosAppStore,
+        "macos-appstore" => ProfileType::MacAppStore,
+        "notarization" => ProfileType::MacAppDirect,
+        _ => anyhow::bail!("unsupported profile type {}", s),
+    })
+}
+
+fn print_profile_header() {
+    println!(
+        "{: <10} | {: <20} | {: <20} | {: <20}",
+        "id", "name", "type", "expiration date"
+    );
+}
+
+fn print_profile(profile: &Profile) {
+    let expiration_date = profile
+        .attributes
+        .expiration_date
+        .split_once('T')
+        .unwrap()
+        .0;
+    println!(
+        "{: <10} | {: <20} | {: <20} | {: <20}",
+        profile.id, profile.attributes.name, profile.attributes.profile_type, expiration_date,
+    );
+}

--- a/app-store-connect/src/main.rs
+++ b/app-store-connect/src/main.rs
@@ -1,3 +1,9 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use anyhow::Result;
 use app_store_connect::bundle_api::{BundleId, BundleIdPlatform};
 use app_store_connect::certs_api::{self, Certificate, CertificateType};
@@ -239,7 +245,7 @@ impl CertificateCommand {
                 let resp = AppStoreConnectClient::from_json_path(&api_key)?.get_certificate(&id)?;
                 let cer = pem::encode(&pem::Pem {
                     tag: "CERTIFICATE".into(),
-                    contents: base64::decode(&resp.data.attributes.certificate_content)?,
+                    contents: base64::decode(resp.data.attributes.certificate_content)?,
                 });
                 println!("{}", cer);
             }
@@ -426,7 +432,7 @@ impl ProfileCommand {
             }
             Self::Get { api_key, id } => {
                 let resp = AppStoreConnectClient::from_json_path(&api_key)?.get_profile(&id)?;
-                let profile = base64::decode(&resp.data.attributes.profile_content)?;
+                let profile = base64::decode(resp.data.attributes.profile_content)?;
                 std::io::stdout().write_all(&profile)?;
             }
             Self::Delete { api_key, id } => {

--- a/app-store-connect/src/main.rs
+++ b/app-store-connect/src/main.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 struct Args {
     /// Path to unified api key.
     #[clap(long, global = true)]
-    api_key: PathBuf,
+    api_key: Option<PathBuf>,
     #[clap(subcommand)]
     command: Commands,
 }
@@ -27,7 +27,11 @@ struct Args {
 fn main() -> Result<()> {
     env_logger::init();
     let args = Args::parse();
-    args.command.run(&args.api_key)
+    if let Some(api_key) = args.api_key.as_ref() {
+        args.command.run(api_key)
+    } else {
+        anyhow::bail!("missing --api-key");
+    }
 }
 
 #[derive(Subcommand)]

--- a/app-store-connect/src/notary_api.rs
+++ b/app-store-connect/src/notary_api.rs
@@ -1,6 +1,8 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
 
 //! App Store Connect Notary API.
 //!

--- a/app-store-connect/src/profile_api.rs
+++ b/app-store-connect/src/profile_api.rs
@@ -1,0 +1,192 @@
+use crate::{AppStoreConnectClient, Result};
+use serde::{Deserialize, Serialize};
+
+const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/profiles";
+
+impl AppStoreConnectClient {
+    pub fn create_profile(
+        &self,
+        name: &str,
+        profile_type: ProfileType,
+        bundle_id: &str,
+        certificates: &[String],
+        devices: Option<&[String]>,
+    ) -> Result<ProfileResponse> {
+        let token = self.get_token()?;
+        let body = ProfileCreateRequest {
+            data: ProfileCreateRequestData {
+                attributes: ProfileCreateRequestAttributes {
+                    name: name.into(),
+                    profile_type: profile_type.to_string(),
+                },
+                relationships: ProfileCreateRequestRelationships {
+                    bundle_id: Ref {
+                        data: RefData {
+                            id: bundle_id.into(),
+                            r#type: "bundleIds".into(),
+                        },
+                    },
+                    certificates: Refs {
+                        data: certificates
+                            .iter()
+                            .map(|certificate| RefData {
+                                id: certificate.into(),
+                                r#type: "certificates".into(),
+                            })
+                            .collect(),
+                    },
+                    devices: devices.map(|devices| Refs {
+                        data: devices
+                            .iter()
+                            .map(|device| RefData {
+                                id: device.into(),
+                                r#type: "devices".into(),
+                            })
+                            .collect(),
+                    }),
+                },
+                r#type: "profiles".into(),
+            },
+        };
+        let req = self
+            .client
+            .post(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .json(&body);
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn list_profiles(&self) -> Result<ProfilesResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(APPLE_CERTIFICATE_URL)
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn get_profile(&self, id: &str) -> Result<ProfileResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(format!("{}/{}", APPLE_CERTIFICATE_URL, id))
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn delete_profile(&self, id: &str) -> Result<()> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .delete(format!("{}/{}", APPLE_CERTIFICATE_URL, id))
+            .bearer_auth(token);
+        self.send_request(req)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileCreateRequest {
+    pub data: ProfileCreateRequestData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileCreateRequestData {
+    pub attributes: ProfileCreateRequestAttributes,
+    pub relationships: ProfileCreateRequestRelationships,
+    pub r#type: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileCreateRequestAttributes {
+    pub name: String,
+    pub profile_type: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileCreateRequestRelationships {
+    pub bundle_id: Ref,
+    pub certificates: Refs,
+    pub devices: Option<Refs>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ref {
+    pub data: RefData,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Refs {
+    pub data: Vec<RefData>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefData {
+    pub id: String,
+    pub r#type: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfileType {
+    IosAppDevelopment,
+    MacAppDevelopment,
+    IosAppStore,
+    MacAppStore,
+    MacAppDirect,
+}
+
+impl std::fmt::Display for ProfileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s = match self {
+            Self::IosAppDevelopment => "IOS_APP_DEVELOPMENT",
+            Self::MacAppDevelopment => "MAC_APP_DEVELOPMENT",
+            Self::IosAppStore => "IOS_APP_STORE",
+            Self::MacAppStore => "MAC_APP_STORE",
+            Self::MacAppDirect => "MAC_APP_DIRECT",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileResponse {
+    pub data: Profile,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfilesResponse {
+    pub data: Vec<Profile>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Profile {
+    pub attributes: ProfileAttributes,
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProfileAttributes {
+    pub name: String,
+    pub platform: String,
+    pub profile_content: String,
+    pub uuid: String,
+    pub created_date: String,
+    pub profile_state: String,
+    pub profile_type: String,
+    pub expiration_date: String,
+}

--- a/app-store-connect/src/profile_api.rs
+++ b/app-store-connect/src/profile_api.rs
@@ -143,7 +143,7 @@ pub struct RefData {
     pub r#type: String,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
 pub enum ProfileType {
     IosAppDevelopment,
     MacAppDevelopment,

--- a/app-store-connect/src/profile_api.rs
+++ b/app-store-connect/src/profile_api.rs
@@ -1,7 +1,13 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use crate::{AppStoreConnectClient, Result};
 use serde::{Deserialize, Serialize};
 
-const APPLE_CERTIFICATE_URL: &'static str = "https://api.appstoreconnect.apple.com/v1/profiles";
+const APPLE_CERTIFICATE_URL: &str = "https://api.appstoreconnect.apple.com/v1/profiles";
 
 impl AppStoreConnectClient {
     pub fn create_profile(

--- a/apple-bundles/src/directory_bundle.rs
+++ b/apple-bundles/src/directory_bundle.rs
@@ -73,7 +73,10 @@ impl DirectoryBundle {
         // case it's safe to check for the existence of the .framework path extension because iOS frameworks
         // aren't versioned. It's furthermore necessary to perform this check, otherwise we would end up
         // assuming that all bundles are frameworks.
-        let framework_plist = if !framework_plist_deep.exists() && root_name.ends_with(".framework") && framework_plist_shallow.exists() {
+        let framework_plist = if !framework_plist_deep.exists()
+            && root_name.ends_with(".framework")
+            && framework_plist_shallow.exists()
+        {
             framework_plist_shallow
         } else {
             framework_plist_deep

--- a/apple-codesign/Cargo.toml
+++ b/apple-codesign/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.68"
+app-store-connect = { version = "0.1.0", path = "../app-store-connect" }
 aws-config = "0.52.0"
 aws-sdk-s3 = "0.22.0"
 aws-smithy-http = "0.52.0"

--- a/apple-codesign/src/cli.rs
+++ b/apple-codesign/src/cli.rs
@@ -4,7 +4,6 @@
 
 use {
     crate::{
-        app_store_connect::UnifiedApiKey,
         certificate::{
             create_self_signed_code_signing_certificate, AppleCertificate, CertificateProfile,
         },
@@ -25,6 +24,7 @@ use {
         signing::UnifiedSigner,
         signing_settings::{SettingsScope, SigningSettings},
     },
+    app_store_connect::UnifiedApiKey,
     clap::{value_parser, Arg, ArgAction, ArgGroup, ArgMatches, Command},
     cryptographic_message_syntax::SignedData,
     difference::{Changeset, Difference},

--- a/apple-codesign/src/error.rs
+++ b/apple-codesign/src/error.rs
@@ -82,9 +82,6 @@ pub enum AppleCodesignError {
     #[error("error parsing version string: {0}")]
     VersionParse(#[from] semver::Error),
 
-    #[error("JWT error: {0}")]
-    Jwt(#[from] jsonwebtoken::errors::Error),
-
     #[error("XAR error: {0}")]
     Xar(#[from] apple_xar::Error),
 
@@ -364,4 +361,7 @@ pub enum AppleCodesignError {
 
     #[error("bad time value")]
     BadTime,
+
+    #[error("{0}")]
+    Anyhow(#[from] anyhow::Error),
 }

--- a/apple-codesign/src/lib.rs
+++ b/apple-codesign/src/lib.rs
@@ -111,7 +111,7 @@
 
 mod apple_certificates;
 pub use apple_certificates::*;
-pub mod app_store_connect;
+pub use app_store_connect;
 mod bundle_signing;
 pub use bundle_signing::*;
 mod certificate;

--- a/apple-codesign/src/lib.rs
+++ b/apple-codesign/src/lib.rs
@@ -111,7 +111,6 @@
 
 mod apple_certificates;
 pub use apple_certificates::*;
-pub use app_store_connect;
 mod bundle_signing;
 pub use bundle_signing::*;
 mod certificate;

--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -16,12 +16,11 @@ and waiting on the availability of a notarization ticket.
 use {
     crate::{
         app_store_connect::{
-            api_token::ConnectTokenEncoder,
             notary_api::{
-                NewSubmissionResponse, NotaryApiClient, SubmissionResponse,
+                NewSubmissionResponse, SubmissionResponse,
                 SubmissionResponseStatus,
             },
-            AppStoreConnectClient,
+            AppStoreConnectClient, ConnectTokenEncoder,
         },
         reader::PathType,
         AppleCodesignError,
@@ -273,18 +272,22 @@ impl Notarizer {
 }
 
 impl Notarizer {
+    fn client(&self) -> Result<AppStoreConnectClient, AppleCodesignError> {
+        match &self.token_encoder {
+            Some(token) => Ok(AppStoreConnectClient::new(
+                token.clone(),
+            )?),
+            None => Err(AppleCodesignError::NotarizeNoAuthCredentials),
+        }
+    }
+
     /// Tell the notary service to expect an upload to S3.
     fn create_submission(
         &self,
         raw_digest: &[u8],
         name: &str,
     ) -> Result<NewSubmissionResponse, AppleCodesignError> {
-        let client = match &self.token_encoder {
-            Some(token) => Ok(NotaryApiClient::from(AppStoreConnectClient::new(
-                token.clone(),
-            )?)),
-            _ => Err(AppleCodesignError::NotarizeNoAuthCredentials),
-        }?;
+        let client = self.client()?;
 
         let digest = hex::encode(raw_digest);
         warn!(
@@ -376,6 +379,13 @@ impl Notarizer {
         Ok(NotarizationUpload::NotaryResponse(status))
     }
 
+    pub fn get_submission(
+        &self,
+        submission_id: &str,
+    ) -> Result<SubmissionResponse, AppleCodesignError> {
+        Ok(self.client()?.get_submission(submission_id)?)
+    }
+
     pub fn wait_on_notarization(
         &self,
         submission_id: &str,
@@ -390,14 +400,7 @@ impl Notarizer {
         let start_time = std::time::Instant::now();
 
         loop {
-            let client = match &self.token_encoder {
-                Some(token) => Ok(NotaryApiClient::from(AppStoreConnectClient::new(
-                    token.clone(),
-                )?)),
-                None => Err(AppleCodesignError::NotarizeNoAuthCredentials),
-            }?;
-
-            let status = client.get_submission(submission_id)?;
+            let status = self.get_submission(submission_id)?;
 
             let elapsed = start_time.elapsed();
 
@@ -428,13 +431,7 @@ impl Notarizer {
         submission_id: &str,
     ) -> Result<serde_json::Value, AppleCodesignError> {
         warn!("fetching notarization log for {}", submission_id);
-        let client = match &self.token_encoder {
-            Some(token) => Ok(NotaryApiClient::from(AppStoreConnectClient::new(
-                token.clone(),
-            )?)),
-            None => Err(AppleCodesignError::NotarizeNoAuthCredentials),
-        }?;
-        client.get_submission_log(submission_id)
+        Ok(self.client()?.get_submission_log(submission_id)?)
     }
 
     /// Waits on an app store package upload and fetches and logs the upload log.

--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -15,15 +15,12 @@ and waiting on the availability of a notarization ticket.
 
 use {
     crate::{
-        app_store_connect::{
-            notary_api::{
-                NewSubmissionResponse, SubmissionResponse,
-                SubmissionResponseStatus,
-            },
-            AppStoreConnectClient, ConnectTokenEncoder,
-        },
         reader::PathType,
         AppleCodesignError,
+    },
+    app_store_connect::{
+        notary_api::{NewSubmissionResponse, SubmissionResponse, SubmissionResponseStatus},
+        AppStoreConnectClient, ConnectTokenEncoder,
     },
     apple_bundles::DirectoryBundle,
     aws_sdk_s3::{Credentials, Region},
@@ -274,9 +271,7 @@ impl Notarizer {
 impl Notarizer {
     fn client(&self) -> Result<AppStoreConnectClient, AppleCodesignError> {
         match &self.token_encoder {
-            Some(token) => Ok(AppStoreConnectClient::new(
-                token.clone(),
-            )?),
+            Some(token) => Ok(AppStoreConnectClient::new(token.clone())?),
             None => Err(AppleCodesignError::NotarizeNoAuthCredentials),
         }
     }


### PR DESCRIPTION
Moves the appstoreconnect api code into it's own crate and extends it with a cli tool and support for the devices, certificates, bundle ids and profiles apis. To generate a key and certificate you can use the following command:

```
asconnect generate-key --api-key path.to.unified.api.key --type development output.key.and.certificate.pem
```