### PR TITLE
Export notary api.

### DIFF
--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -15,7 +15,7 @@ and waiting on the availability of a notarization ticket.
 
 use {
     crate::{reader::PathType, AppleCodesignError},
-    app_store_connect::{notary_api, AppStoreConnectClient, ConnectTokenEncoder, UnifiedApiKey},
+    app_store_connect::{AppStoreConnectClient, ConnectTokenEncoder, UnifiedApiKey},
     apple_bundles::DirectoryBundle,
     aws_sdk_s3::{Credentials, Region},
     aws_smithy_http::byte_stream::ByteStream,
@@ -28,6 +28,7 @@ use {
         time::Duration,
     },
 };
+pub use app_store_connect::notary_api;
 
 fn digest<H: Digest, R: Read>(reader: &mut R) -> Result<(u64, Vec<u8>), AppleCodesignError> {
     let mut hasher = H::new();


### PR DESCRIPTION
This change was dropped from my PR. Wanted to reopen to discuss it in more detail.

A consumer of the notarization api would have to add `app-store-connect` as a dependency and hope that the version matches the one required by apple-codesign. This is because the response types of the `notary_api` are part of the public api of the `Notarizer`. I think a crate should export all types in it's public api. An alternative would be to try to remove the types from the public api, by wrapping them with types in this crate that hide the inner type. But in this case I think that reexporting notary_api is the sensible thing to do. wdyt?