### PR TITLE
Tentative fix for issue #77

### DIFF
--- a/apple-codesign/src/bundle_signing.rs
+++ b/apple-codesign/src/bundle_signing.rs
@@ -563,14 +563,15 @@ impl SingleBundleSigner {
         // don't appear to include digests of any nested app bundles. So we add that
         // exclusion. iOS bundles don't seem to include digests for nested bundles either.
         // We should figure out what the actual rules here...
-        if !self.bundle.shallow() {
-            let dest_bundle = DirectoryBundle::new_from_path(&dest_dir)
-                .map_err(AppleCodesignError::DirectoryBundle)?;
+        let dest_bundle = DirectoryBundle::new_from_path(&dest_dir)
+            .map_err(AppleCodesignError::DirectoryBundle)?;
 
-            for (rel_path, nested_bundle) in dest_bundle
-                .nested_bundles(false)
-                .map_err(AppleCodesignError::DirectoryBundle)?
-            {
+        for (rel_path, nested_bundle) in dest_bundle
+            .nested_bundles(false)
+            .map_err(AppleCodesignError::DirectoryBundle)?
+        {
+            // Apple's codesign seems to only sign nested bundles if they have a "." in the name.
+            if nested_bundle.name().contains('.') {
                 resources_builder.process_nested_bundle(&rel_path, &nested_bundle)?;
             }
         }

--- a/apple-codesign/src/code_resources.rs
+++ b/apple-codesign/src/code_resources.rs
@@ -713,6 +713,7 @@ impl CodeResources {
         let data = String::from_utf8(data).expect("XML should be valid UTF-8");
         let data = data.replace("<dict />", "<dict/>");
         let data = data.replace("<true />", "<true/>");
+        let data = data.replace("&quot;", "\"");
 
         writer.write_all(data.as_bytes())?;
         writer.write_all(b"\n")?;
@@ -1314,8 +1315,12 @@ impl CodeResourcesBuilder {
 
         let (relative_path, optional) =
             match Self::evaluate_rules(&self.rules2, relative_path, None)? {
-                RulesEvaluation::SealRegularFile(relative_path, optional) => {
-                    (relative_path, optional)
+                RulesEvaluation::SealRegularFile(relative_path, _) => {
+                    info!(
+                        "excluding signing nested bundle {} because of matched resources rule",
+                        relative_path
+                    );
+                    return Ok(());
                 }
                 RulesEvaluation::SealNested(relative_path, optional) => (relative_path, optional),
                 RulesEvaluation::Exclude => {

--- a/apple-codesign/src/embedded_signature_builder.rs
+++ b/apple-codesign/src/embedded_signature_builder.rs
@@ -303,6 +303,17 @@ impl<'a> EmbeddedSignatureBuilder<'a> {
         Ok(())
     }
 
+    pub fn create_empty_cms_signature(
+        &mut self,
+    ) -> Result<(), AppleCodesignError> {
+        self.blobs.insert(
+            CodeSigningSlot::Signature,
+            BlobData::BlobWrapper(Box::new(BlobWrapperBlob::from_data_owned(Vec::new()))),
+        );
+        self.state = BlobsState::SignatureAdded;
+        Ok(())
+    }
+
     /// Add notarization ticket data.
     ///
     /// This will register a new ticket slot holding the notarization ticket data.

--- a/apple-codesign/src/macho_signing.rs
+++ b/apple-codesign/src/macho_signing.rs
@@ -396,6 +396,8 @@ impl<'data> MachOSigner<'data> {
                 settings.time_stamp_url(),
                 settings.certificate_chain().iter().cloned(),
             )?;
+        } else {
+            builder.create_empty_cms_signature()?;
         }
 
         builder.create_superblob()


### PR DESCRIPTION
I've carefully inspected apple's source code to identify differences between using "codesign" vs using "rcodesign" to sign the Sparkle framework.
The code in this change successfully creates the appropriate sealed resources. The main differences are:
1) Always process nested bundles, even if the bundle is shallow. That is a bold move, but also:
2) Only sign nested bundles that contain a "." in the name. That is literally how Apple does it. And:
3) Only sign nested bundles if they match a "nested" rule. That is also in the Apple source code.

It would be useful to have test cases including situations where you observed that framework bundles didn't include nested bundles in the resources, to see if my changes keep the correct behavior.