### PR TITLE
feat: add support for proxy auth

### DIFF
--- a/apple-codesign/Cargo.toml
+++ b/apple-codesign/Cargo.toml
@@ -19,7 +19,8 @@ path = "src/main.rs"
 anyhow = "1.0.71"
 aws-config = { version = "0.56.0", optional = true }
 aws-sdk-s3 = { version = "0.29.0", optional = true }
-aws-smithy-http = {version = "0.56.0", optional = true }
+aws-smithy-client = { version = "0.56.1", features = ["rustls", "client-hyper"] }
+aws-smithy-http = {version = "0.56.1", optional = true }
 base64 = "0.21.2"
 bcder = "0.7.2"
 bitflags = "2.3.1"
@@ -38,6 +39,9 @@ filetime = "0.2.21"
 glob = "0.3.1"
 goblin = "0.6.1"
 hex = "0.4.3"
+headers = "0.3.8"
+hyper = { version = "0.14.27", features = ["client"] }
+hyper-proxy = "0.9.1"
 log = "0.4.18"
 md-5 = "0.10.5"
 minicbor = { version = "0.19.1", features = ["derive", "std"] }

--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -20,9 +20,13 @@ use {
     apple_bundles::DirectoryBundle,
     aws_sdk_s3::config::{Credentials, Region},
     aws_smithy_http::byte_stream::ByteStream,
+    headers::Authorization,
+    hyper::Uri,
+    hyper_proxy::{Proxy, Intercept, ProxyConnector},
     log::{info, warn},
     sha2::Digest,
     std::{
+        env
         fs::File,
         io::{Read, Seek, SeekFrom, Write},
         path::{Path, PathBuf},
@@ -311,8 +315,33 @@ impl Notarizer {
                 .load(),
         );
 
-        let s3_client = aws_sdk_s3::Client::new(&config);
+        let proxy = {
+          let http_proxy = env::var_os("http_proxy");
+          let proxy_uri = http_proxy.unwrap().to_str().unwrap().parse::<Uri>().unwrap();
+          let mut proxy = Proxy::new(Intercept::All, proxy_uri);
 
+          let proxy_user = env::var_os("proxy_user");
+          let proxy_password = env::var_os("proxy_password");
+
+          match (proxy_user, proxy_password) {
+            (Some(user), Some(password)) => {
+              proxy.set_authorization(Authorization::basic(user.to_str().unwrap(), password.to_str().unwrap()));
+            }
+            _ => {}
+          }
+
+          let connector = hyper::client::HttpConnector::new();
+          let proxy_connector = ProxyConnector::from_proxy(connector, proxy).unwrap();
+          proxy_connector
+        };        
+
+        let hyper_client = aws_smithy_client::hyper_ext::Adapter::builder()
+          .build(proxy);
+        // let hyper_client = hyper_ext::Adapter::builder().build(proxy);
+        let proxy_config = aws_sdk_s3::config::Builder::from(&config).http_connector(hyper_client).build();
+        let s3_client = aws_sdk_s3::client::Client::from_conf(proxy_config);
+        //let s3_client = aws_sdk_s3::Client::new(&config);
+        
         warn!(
             "uploading asset to s3://{}/{}",
             submission.data.attributes.bucket, submission.data.attributes.object


### PR DESCRIPTION
Support added for proxy authentication. This does not add tests to validate proxy / noproxy use cases, nor is this validated against non proxy environments, but is fully functional in a corporate proxy-backed environment. 

Co-Authors: @cbacken / https://github.com/cbacken