### PR TITLE
fix: build errors when no features are enabled

### DIFF
--- a/apple-codesign/src/cli/mod.rs
+++ b/apple-codesign/src/cli/mod.rs
@@ -2313,6 +2313,7 @@ impl Subcommands {
             Subcommands::DebugCreateMacho(c) => c,
             Subcommands::DebugFileTree(c) => c,
             Subcommands::DiffSignatures(c) => c,
+            #[cfg(feature = "notarize")]
             Subcommands::EncodeAppStoreConnectApiKey(c) => c,
             Subcommands::Extract(c) => c,
             Subcommands::GenerateCertificateSigningRequest(c) => c,
@@ -2320,8 +2321,11 @@ impl Subcommands {
             Subcommands::KeychainExportCertificateChain(c) => c,
             Subcommands::KeychainPrintCertificates(c) => c,
             Subcommands::MachoUniversalCreate(c) => c,
+            #[cfg(feature = "notarize")]
             Subcommands::NotaryLog(c) => c,
+            #[cfg(feature = "notarize")]
             Subcommands::NotarySubmit(c) => c,
+            #[cfg(feature = "notarize")]
             Subcommands::NotaryWait(c) => c,
             Subcommands::ParseCodeSigningRequirement(c) => c,
             Subcommands::PrintSignatureInfo(c) => c,


### PR DESCRIPTION
When the `notarize` feature is not enabled, some enum variants from the `Subcommands` were not included. This change ensures that is also done in the place where these variants are used.

Without this chance the following errors are reported when not building with default features:

```
error[E0599]: no variant or associated item named `EncodeAppStoreConnectApiKey` found for enum `Subcommands` in the current scope
    --> apple-codesign\src\cli\mod.rs:2316:26
     |
1850 | enum Subcommands {
     | ---------------- variant or associated item `EncodeAppStoreConnectApiKey` not found for this enum
...
2316 |             Subcommands::EncodeAppStoreConnectApiKey(c) => c,
     |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ variant or associated item not found in `Subcommands`

error[E0599]: no variant or associated item named `NotaryLog` found for enum `Subcommands` in the current scope
    --> apple-codesign\src\cli\mod.rs:2323:26
     |
1850 | enum Subcommands {
     | ---------------- variant or associated item `NotaryLog` not found for this enum
...
2323 |             Subcommands::NotaryLog(c) => c,
     |                          ^^^^^^^^^ variant or associated item not found in `Subcommands`

error[E0599]: no variant or associated item named `NotarySubmit` found for enum `Subcommands` in the current scope
    --> apple-codesign\src\cli\mod.rs:2324:26
     |
1850 | enum Subcommands {
     | ---------------- variant or associated item `NotarySubmit` not found for this enum
...
2324 |             Subcommands::NotarySubmit(c) => c,
     |                          ^^^^^^^^^^^^ variant or associated item not found in `Subcommands`

error[E0599]: no variant or associated item named `NotaryWait` found for enum `Subcommands` in the current scope
    --> apple-codesign\src\cli\mod.rs:2325:26
     |
1850 | enum Subcommands {
     | ---------------- variant or associated item `NotaryWait` not found for this enum
...
2325 |             Subcommands::NotaryWait(c) => c,
     |                          ^^^^^^^^^^ variant or associated item not found in `Subcommands`
```