### PR TITLE
Add a cli option to get notarization submission list

### DIFF
--- a/app-store-connect/src/notary_api.rs
+++ b/app-store-connect/src/notary_api.rs
@@ -127,6 +127,14 @@ impl SubmissionResponse {
     }
 }
 
+/// The notary service’s response to a request for the list of submissions.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListSubmissionResponse {
+    pub data: Vec<SubmissionResponseData>,
+    pub meta: Value,
+}
+
 #[derive(Clone, Copy, Debug, Error)]
 #[error("notarization {0}")]
 pub struct NotarizationError(SubmissionResponseStatus);
@@ -189,6 +197,17 @@ impl AppStoreConnectClient {
             .get(format!(
                 "{APPLE_NOTARY_SUBMIT_SOFTWARE_URL}/{submission_id}"
             ))
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn list_submissions(&self) -> Result<ListSubmissionResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(APPLE_NOTARY_SUBMIT_SOFTWARE_URL)
             .bearer_auth(token)
             .header("Accept", "application/json");
 

--- a/apple-codesign/src/cli/mod.rs
+++ b/apple-codesign/src/cli/mod.rs
@@ -766,6 +766,29 @@ impl CliCommand for MachoUniversalCreate {
 
 #[cfg(feature = "notarize")]
 #[derive(Parser)]
+struct NotaryList {
+    #[command(flatten)]
+    api: NotaryApi,
+}
+
+#[cfg(feature = "notarize")]
+impl CliCommand for NotaryList {
+    fn run(&self, _context: &Context) -> Result<(), AppleCodesignError> {
+        let notarizer = self.api.notarizer()?;
+
+        let submissions = notarizer.list_submissions()?;
+
+        for entry in &submissions.data {
+            println!("{} {} {} {} {}", entry.id, entry.attributes.created_date, entry.attributes.name, entry.r#type, entry.attributes.status);
+        }
+
+        Ok(())
+    }
+}
+
+
+#[cfg(feature = "notarize")]
+#[derive(Parser)]
 struct NotaryLog {
     /// The ID of the previous submission to wait on
     submission_id: String,
@@ -1970,6 +1993,10 @@ enum Subcommands {
     MachoUniversalCreate(MachoUniversalCreate),
 
     #[cfg(feature = "notarize")]
+    /// List notarization submissions
+    NotaryList(NotaryList),
+
+    #[cfg(feature = "notarize")]
     /// Fetch the notarization log for a previous submission
     NotaryLog(NotaryLog),
 
@@ -2321,6 +2348,7 @@ impl Subcommands {
             Subcommands::KeychainPrintCertificates(c) => c,
             Subcommands::MachoUniversalCreate(c) => c,
             Subcommands::NotaryLog(c) => c,
+            Subcommands::NotaryList(c) => c,
             Subcommands::NotarySubmit(c) => c,
             Subcommands::NotaryWait(c) => c,
             Subcommands::ParseCodeSigningRequirement(c) => c,

--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -431,4 +431,8 @@ impl Notarizer {
 
         Ok(status)
     }
+
+    pub fn list_submissions(&self) -> Result<notary_api::ListSubmissionResponse, AppleCodesignError> {
+        Ok(self.client()?.list_submissions()?)
+    }
 }

--- a/apple-codesign/tests/cmd/help.trycmd
+++ b/apple-codesign/tests/cmd/help.trycmd
@@ -26,6 +26,8 @@ Commands:
           Print information about certificates in the macOS keychain
   macho-universal-create
           Create a universal ("fat") Mach-O binary
+  notary-list
+          List notarization submissions
   notary-log
           Fetch the notarization log for a previous submission
   notary-submit
@@ -95,6 +97,8 @@ Commands:
           Print information about certificates in the macOS keychain
   macho-universal-create
           Create a universal ("fat") Mach-O binary
+  notary-list
+          List notarization submissions
   notary-log
           Fetch the notarization log for a previous submission
   notary-submit


### PR DESCRIPTION
Adds a new `rcodesign notary-list` command that lists the last 100 notarization requests that was done on this account, and prints information about them. This is essentially a pretty print around [this endpoint](https://developer.apple.com/documentation/notaryapi/get_previous_submissions).