### PR TITLE
apple-sdk: support reading path set by `xcode-select --switch`

### DIFF
--- a/apple-sdk/CHANGELOG.md
+++ b/apple-sdk/CHANGELOG.md
@@ -9,6 +9,9 @@ Released on ReleaseDate.
 * XROS support. `Platform` enumeration added `XrOs` and `XrOsSimulator`
   variants. The `aarch64-apple-xros-sim` and `*-apple-xros` triples are
   now recognized as XROS.
+* The developer directory configured with `xcode-select --switch PATH` can now
+  be retrieved by using `DeveloperDirectory::from_xcode_select_paths`, and
+  this is done by default when searching for SDKs.
 
 ## 0.5.2
 


### PR DESCRIPTION
The user can set the current developer directory globally by using `xcode-select --switch PATH`.

This creates a symlink at `/var/db/xcode_select_link`, which we can read to get the path of the current globally configured developer directory. In the past, other files were created instead, so we also attempt to read those (we could probably omit this logic, but might as well include it for completeness).

I'm fairly confident that this is the last thing needed for `SdkSearch::default()` to perform exactly the same lookup as `xcode-select --print-path` itself.

See also https://github.com/rust-lang/rust/pull/131433 where I implemented similar logic in `rustc`.