### PR TITLE
fix: add id attribute for extended attribute struct

### DIFF
--- a/apple-xar/src/table_of_contents.rs
+++ b/apple-xar/src/table_of_contents.rs
@@ -505,6 +505,7 @@ pub struct FileEncoding {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Ea {
+    pub id: u64,
     pub name: String,
     pub offset: u64,
     pub size: u64,
@@ -516,7 +517,7 @@ pub struct Ea {
 
 impl Ea {
     pub fn write_xml<W: Write>(&self, writer: &mut EventWriter<W>) -> XarResult<()> {
-        writer.write(XmlEvent::start_element("ea"))?;
+        writer.write(XmlEvent::start_element("ea").attr("id", &format!("{}", self.id)))?;
 
         writer.write(XmlEvent::start_element("name"))?;
         writer.write(XmlEvent::characters(&self.name))?;


### PR DESCRIPTION
This fixes #140 .

The Extended Attribute structure has an additional id attribute,

See the output of a header.xml file:

```
    <ea id="0">
     <name>com.apple.TextEncoding</name>
     <archived-checksum style="sha1">d433dacc26ca2c81f30c25e807dc170e6680aad9</archived-checksum>
     <extracted-checksum style="sha1">34bb265cb6732969f269ccc90fea5d662e9e0ea5</extracted-checksum>
     <encoding style="application/x-gzip"/>
     <size>15</size>
     <offset>41292523</offset>
     <length>23</length>
    </ea>
```

This fix adds the attribute and writes is accordingly.