### PR TITLE
chore: relax url requirement

### DIFF
--- a/apple-xar/Cargo.toml
+++ b/apple-xar/Cargo.toml
@@ -30,7 +30,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 signature = { version = "2.2.0", features = ["std"], optional = true }
 thiserror = "1.0.56"
-url = "2"
+url = ">=2.4.0, <3"
 xml-rs = "0.8.19"
 x509-certificate = "0.23.1"
 xz2 = { version = "0.1.7", features = ["static"] }

--- a/apple-xar/Cargo.toml
+++ b/apple-xar/Cargo.toml
@@ -30,7 +30,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 signature = { version = "2.2.0", features = ["std"], optional = true }
 thiserror = "1.0.56"
-url = "2.5.0"
+url = "2"
 xml-rs = "0.8.19"
 x509-certificate = "0.23.1"
 xz2 = { version = "0.1.7", features = ["static"] }


### PR DESCRIPTION
i'm facing some issues because some crates expect a particular version for the URL crate (for instance [deno](https://github.com/denoland/deno/blob/2de4faa483982478e9a36ad4ab891a887b4779f1/Cargo.toml#L200)). Relaxing the url requirement is helpful, unless you're also requiring some changes introduced in 2.5