### PR TITLE
apple-codesign: honor verbose level to set logging level

### DIFF
--- a/apple-codesign/src/cli/mod.rs
+++ b/apple-codesign/src/cli/mod.rs
@@ -2499,9 +2499,11 @@ pub fn main_impl() -> Result<(), AppleCodesignError> {
         _ => LevelFilter::Trace,
     };
 
-    let mut builder = env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or(log_level.as_str()),
-    );
+    let mut builder = env_logger::Builder::new();
+
+    builder
+        .filter_level(log_level)
+        .parse_default_env();
 
     // Disable log context except at higher log levels.
     if log_level <= LevelFilter::Info {


### PR DESCRIPTION
While updating rcodesign in nixpkgs, I ran into failing tests with cli_tests. It seems the verbosity flag used by the tests is not being honored. With this patch, verbosity level sets the default logging level, which can be overriden with the `RUST_LOG` environment variable.