### PR TITLE
feat(app-store-connect): APIs to get bundle ID and profile relationships

### DIFF
--- a/app-store-connect/src/certs_api.rs
+++ b/app-store-connect/src/certs_api.rs
@@ -122,6 +122,7 @@ pub enum CertificateType {
     Development,
     Distribution,
     DeveloperIdApplication,
+    IosDistribution,
 }
 
 impl std::fmt::Display for CertificateType {
@@ -130,6 +131,7 @@ impl std::fmt::Display for CertificateType {
             Self::Development => "DEVELOPMENT",
             Self::Distribution => "DISTRIBUTION",
             Self::DeveloperIdApplication => "DEVELOPER_ID_APPLICATION",
+            Self::IosDistribution => "IOS_DISTRIBUTION",
         };
         write!(f, "{s}")
     }

--- a/app-store-connect/src/cli.rs
+++ b/app-store-connect/src/cli.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::bundle_api::{BundleId, BundleIdPlatform};
+use crate::bundle_api::{BundleCapability, BundleId, BundleIdPlatform};
 use crate::certs_api::{self, Certificate, CertificateType};
 use crate::device_api::Device;
 use crate::profile_api::{Profile, ProfileType};
@@ -102,6 +102,14 @@ pub enum BundleCommand {
         /// Id of certificate.
         id: String,
     },
+    GetProfiles {
+        /// Id of certificate.
+        id: String,
+    },
+    GetCapabilities {
+        /// Id of certificate.
+        id: String,
+    },
     Delete {
         /// Id of bundle id to revoke.
         id: String,
@@ -129,6 +137,20 @@ impl BundleCommand {
                 print_bundle_id_header();
                 print_bundle_id(&resp.data);
             }
+            Self::GetCapabilities { id } => {
+                let resp = client.list_bundle_capabilities(&id)?;
+                print_capability_header();
+                for capability in resp.data {
+                    print_capability(&capability);
+                }
+            }
+            Self::GetProfiles { id } => {
+                let resp = client.list_bundle_profiles(&id)?;
+                print_profile_header();
+                for profile in &resp.data {
+                    print_profile(profile);
+                }
+            }
             Self::Delete { id } => {
                 client.delete_bundle_id(&id)?;
             }
@@ -145,6 +167,17 @@ fn print_bundle_id(bundle_id: &BundleId) {
     println!(
         "{: <10} | {: <20} | {: <30}",
         bundle_id.id, bundle_id.attributes.name, bundle_id.attributes.identifier,
+    );
+}
+
+fn print_capability_header() {
+    println!("{: <10} | {: <20}", "id", "type");
+}
+
+fn print_capability(capability: &BundleCapability) {
+    println!(
+        "{: <10} | {: <20}",
+        capability.id, capability.attributes.capability_type
     );
 }
 
@@ -302,11 +335,19 @@ pub enum ProfileCommand {
     },
     List,
     Get {
-        /// Id of device.
+        /// Id of profile.
         id: String,
     },
     Delete {
-        /// Id of device.
+        /// Id of profile.
+        id: String,
+    },
+    GetBundleId {
+        /// Id of profile.
+        id: String,
+    },
+    GetCertificates {
+        /// Id of profile.
         id: String,
     },
 }
@@ -346,6 +387,18 @@ impl ProfileCommand {
             }
             Self::Delete { id } => {
                 client.delete_profile(&id)?;
+            }
+            Self::GetBundleId { id } => {
+                let bundle_id = client.get_profile_bundle_id(&id)?;
+                print_bundle_id_header();
+                print_bundle_id(&bundle_id.data);
+            }
+            Self::GetCertificates { id } => {
+                let resp = client.list_profile_certificates(&id)?;
+                print_certificate_header();
+                for cert in &resp.data {
+                    print_certificate(cert);
+                }
             }
         }
         Ok(())

--- a/app-store-connect/src/cli.rs
+++ b/app-store-connect/src/cli.rs
@@ -4,7 +4,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::bundle_api::{BundleCapability, BundleId, BundleIdPlatform};
+use crate::bundle_api::{
+    BundleCapability, BundleId, BundleIdCapabilityCreateRequestDataAttributes, BundleIdPlatform,
+};
 use crate::certs_api::{self, Certificate, CertificateType};
 use crate::device_api::Device;
 use crate::profile_api::{Profile, ProfileType};
@@ -99,16 +101,22 @@ pub enum BundleCommand {
     },
     List,
     Get {
-        /// Id of certificate.
+        /// Id of bundle id.
         id: String,
     },
     GetProfiles {
-        /// Id of certificate.
+        /// Id of bundle id.
         id: String,
     },
     GetCapabilities {
-        /// Id of certificate.
+        /// Id of bundle id.
         id: String,
+    },
+    EnableCapability {
+        /// Id of bundle id.
+        id: String,
+        /// Capability type.
+        capability: String,
     },
     Delete {
         /// Id of bundle id to revoke.
@@ -143,6 +151,15 @@ impl BundleCommand {
                 for capability in resp.data {
                     print_capability(&capability);
                 }
+            }
+            Self::EnableCapability { id, capability } => {
+                client.enable_bundle_id_capability(
+                    &id,
+                    BundleIdCapabilityCreateRequestDataAttributes {
+                        capability_type: capability.clone(),
+                    },
+                )?;
+                println!("capability {capability} enabled for bundle ID {id}");
             }
             Self::GetProfiles { id } => {
                 let resp = client.list_bundle_profiles(&id)?;

--- a/app-store-connect/src/profile_api.rs
+++ b/app-store-connect/src/profile_api.rs
@@ -4,10 +4,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{AppStoreConnectClient, Result};
+use crate::{
+    bundle_api::BundleIdResponse, certs_api::CertificatesResponse, AppStoreConnectClient, Result,
+};
 use serde::{Deserialize, Serialize};
 
-const APPLE_CERTIFICATE_URL: &str = "https://api.appstoreconnect.apple.com/v1/profiles";
+const APPLE_PROFILES_URL: &str = "https://api.appstoreconnect.apple.com/v1/profiles";
 
 impl AppStoreConnectClient {
     pub fn create_profile(
@@ -56,7 +58,7 @@ impl AppStoreConnectClient {
         };
         let req = self
             .client
-            .post(APPLE_CERTIFICATE_URL)
+            .post(APPLE_PROFILES_URL)
             .bearer_auth(token)
             .header("Accept", "application/json")
             .header("Content-Type", "application/json")
@@ -64,11 +66,31 @@ impl AppStoreConnectClient {
         Ok(self.send_request(req)?.json()?)
     }
 
+    pub fn get_profile_bundle_id(&self, profile_id: &str) -> Result<BundleIdResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(format!("{APPLE_PROFILES_URL}/{profile_id}/bundleId"))
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
+    pub fn list_profile_certificates(&self, profile_id: &str) -> Result<CertificatesResponse> {
+        let token = self.get_token()?;
+        let req = self
+            .client
+            .get(format!("{APPLE_PROFILES_URL}/{profile_id}/certificates"))
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        Ok(self.send_request(req)?.json()?)
+    }
+
     pub fn list_profiles(&self) -> Result<ProfilesResponse> {
         let token = self.get_token()?;
         let req = self
             .client
-            .get(APPLE_CERTIFICATE_URL)
+            .get(APPLE_PROFILES_URL)
             .bearer_auth(token)
             .header("Accept", "application/json");
         Ok(self.send_request(req)?.json()?)
@@ -78,7 +100,7 @@ impl AppStoreConnectClient {
         let token = self.get_token()?;
         let req = self
             .client
-            .get(format!("{APPLE_CERTIFICATE_URL}/{id}"))
+            .get(format!("{APPLE_PROFILES_URL}/{id}"))
             .bearer_auth(token)
             .header("Accept", "application/json");
         Ok(self.send_request(req)?.json()?)
@@ -88,7 +110,7 @@ impl AppStoreConnectClient {
         let token = self.get_token()?;
         let req = self
             .client
-            .delete(format!("{APPLE_CERTIFICATE_URL}/{id}"))
+            .delete(format!("{APPLE_PROFILES_URL}/{id}"))
             .bearer_auth(token);
         self.send_request(req)?;
         Ok(())
@@ -191,7 +213,7 @@ pub struct ProfileAttributes {
     pub platform: String,
     pub profile_content: String,
     pub uuid: String,
-    pub created_date: String,
+    pub created_date: Option<String>,
     pub profile_state: String,
     pub profile_type: String,
     pub expiration_date: String,


### PR DESCRIPTION
This changes the app-store-connect package to include APIs to:
- list the capabilities associated with a bundle ID
- list the profiles associated with a bundle ID
- enable a capability for a bundle ID
- get the bundle ID associated with a profile
- list the certificates associated with a profile