### PR TITLE
chore: relax url dependency requirement

### DIFF
--- a/apple-xar/Cargo.toml
+++ b/apple-xar/Cargo.toml
@@ -30,7 +30,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 signature = { version = "2.2.0", features = ["std"], optional = true }
 thiserror = "1.0.67"
-url = "2.5.2"
+url = "2"
 xml-rs = "0.8.22"
 x509-certificate = "0.24.0"
 xz2 = { version = "0.1.7", features = ["static"] }


### PR DESCRIPTION
Unfortunately I'm using the apple-codesign crate in a workspace that also includes a crate that relies on `url = "< 2.5"` so I have a conflict in the dependency requirement. Can we relax the requirement to `url = "2"` in this crate?