### PR TITLE
workspace: bzip2 0.4 -> 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,22 +943,20 @@ checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -4530,7 +4528,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/apple-xar/Cargo.toml
+++ b/apple-xar/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 base64 = "0.22.1"
 bcder = { version = "0.7.4", optional = true }
-bzip2 = "0.4.4"
+bzip2 = "0.5"
 chrono = { version = "0.4.38", features = ["serde"] }
 cryptographic-message-syntax = { version = "0.27.0", optional = true }
 digest = "0.10.7"


### PR DESCRIPTION
This updates the bzip2 dependency from 0.4 to 0.5. There are no breaking changes that affect this project:

- The update to the MSRV 1.65 / 2021 Edition has no effect, this project already has higher requirements.
- The dropped deprecated / obsolete feature flags are not in use here.

https://github.com/trifectatechfoundation/bzip2-rs/releases/tag/v0.5.0