### PR TITLE
cargo: update serde-xml-rs to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3576,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "serde-xml-rs"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
+checksum = "c6560602b989198ebb381e3192c86970116b3b2e13b8b8a39d6d0850e40b6b81"
 dependencies = [
  "log",
  "serde",
@@ -4530,7 +4530,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/apple-flat-package/Cargo.toml
+++ b/apple-flat-package/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 flate2 = "1.0.35"
 scroll = { version = "0.12.0", features = ["derive"] }
-serde-xml-rs = "0.6.0"
+serde-xml-rs = "0.7.1"
 serde = { version = "1.0.215", features = ["derive"] }
 thiserror = "2.0.3"
 

--- a/apple-xar/Cargo.toml
+++ b/apple-xar/Cargo.toml
@@ -24,7 +24,7 @@ flate2 = "1.0.35"
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.12.9", default-features = false, optional = true }
 scroll = { version = "0.12.0", features = ["derive"] }
-serde-xml-rs = "0.6.0"
+serde-xml-rs = "0.7.1"
 serde = { version = "1.0.215", features = ["derive"] }
 sha1 = "0.10.6"
 sha2 = "0.10.8"


### PR DESCRIPTION
This is the last upgradable version without breaking changes.

---

Allows Fedora to update serdel-xml-rs to 0.7.1 without having to patch Cargo.toml.