### PR TITLE
apple-codesign: Add PKCS#11 support

### DIFF
--- a/.github/workflows/pkcs11-sign-apple-exe.yml
+++ b/.github/workflows/pkcs11-sign-apple-exe.yml
@@ -1,0 +1,150 @@
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  EXE_NAME: "rcodesign"
+  PKCS11_PIN: "12345"
+  KEY_LABEL: "mykey"
+
+jobs:
+  sign:
+    name: Test SoftHSM Code Signing
+    runs-on: 'ubuntu-24.04'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install SoftHSM and PKCS#11 tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y softhsm2 openssl opensc
+
+      - name: Create SoftHSM config
+        run: |
+          cat > softhsm2.conf << EOF
+          directories.tokendir = ${{ github.workspace }}/tokens/
+          objectstore.backend = file
+          log.level = DEBUG
+          EOF
+          mkdir -p tokens/
+
+      - name: Setup SoftHSM token
+        run: |
+          # Create SoftHSM configuration directory
+          mkdir -p ~/.config/softhsm2
+
+          # Initialize token
+          softhsm2-util --init-token --slot 0 --label "CodeSigning" --so-pin 123456 --pin $PKCS11_PIN
+
+          # List tokens to verify setup
+          softhsm2-util --show-slots
+
+          # Get the slot ID of the initialized token (with label "CodeSigning")
+          SLOT_ID=$(softhsm2-util --show-slots | awk '/^Slot [0-9]/ {slot=$2} /Label:.*CodeSigning/ {print slot; exit}')
+          echo "SLOT_ID=$SLOT_ID" >> $GITHUB_ENV
+          echo "Using slot ID: $SLOT_ID"
+        env:
+          SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf
+
+      - name: Download rcodesign from current build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: exe-rcodesign-x86_64-unknown-linux-gnu
+          path: bins/
+
+      - name: Download rcodesign artifact (macOS for signing target)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: exe-rcodesign-aarch64-apple-darwin
+          path: dist/input/
+
+      - name: Check macOS binary
+        run: |
+          cd dist/input/
+          echo "Available files in dist/input/:"
+          ls -la
+          echo "Binary to sign: $(file $EXE_NAME)"
+
+      - name: Prepare rcodesign binary for signing
+        run: |
+          # Ensure rcodesign was downloaded
+          if [ ! -f "bins/rcodesign" ]; then
+            echo "❌ rcodesign binary not found in bins/"
+            echo "Available files in bins/:"
+            ls -la bins/ || echo "bins/ directory doesn't exist"
+            exit 1
+          fi
+
+          # Make it executable
+          chmod +x bins/rcodesign
+
+          # Verify it works
+          ./bins/rcodesign --version || echo "Warning: rcodesign --version failed"
+
+          echo "✅ rcodesign binary ready for signing"
+
+      - name: Create test certificate and private key
+        run: |
+          # Generate a private key
+          openssl genrsa -out private_key.pem 2048
+
+          # Create a self-signed certificate (for testing)
+          openssl req -new -x509 -key private_key.pem -out test_cert.pem -days 365 -subj "/CN=Test Code Signing/O=Test Organization/C=US"
+
+          # Convert certificate to DER format (what PKCS#11 expects)
+          openssl x509 -in test_cert.pem -outform DER -out developerID_application.cer
+
+          # Import certificate
+          pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
+            --login --pin $PKCS11_PIN \
+            --slot $SLOT_ID \
+            --write-object developerID_application.cer \
+            --type cert \
+            --label "cert"
+
+          # Import private key
+          pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
+            --login --pin $PKCS11_PIN \
+            --slot $SLOT_ID \
+            --write-object private_key.pem \
+            --type privkey \
+            --label $KEY_LABEL
+        env:
+          SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf
+
+      - name: List PKCS#11 objects (debug)
+        run: |
+          pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
+            --login --pin $PKCS11_PIN \
+            --slot $SLOT_ID \
+            --list-objects
+        env:
+          SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf
+
+      - name: Perform SoftHSM code signing
+        run: |
+          # Ensure output directory exists
+          mkdir -p dist/output
+
+          # Make rcodesign executable
+          chmod +x bins/rcodesign
+
+          # Sign the executable
+          bins/rcodesign sign \
+              --pkcs11-library /usr/lib/softhsm/libsofthsm2.so \
+              --pkcs11-certificate-file developerID_application.cer \
+              --pkcs11-key-label $KEY_LABEL \
+              --pkcs11-slot-id $SLOT_ID \
+              --pkcs11-pin $PKCS11_PIN \
+              --code-signature-flags runtime \
+              dist/input/$EXE_NAME \
+              dist/output/$EXE_NAME
+        env:
+          SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf
+
+      - name: Upload signed artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: exe-${{ env.EXE_NAME }}-softhsm-signed
+          path: dist/output/${{ env.EXE_NAME }}

--- a/.github/workflows/rcodesign.yml
+++ b/.github/workflows/rcodesign.yml
@@ -21,3 +21,8 @@ jobs:
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  test-softhsm-signing:
+    name: PKCS#11 Test
+    uses: ./.github/workflows/pkcs11-sign-apple-exe.yml
+    needs: [exes]

--- a/.github/workflows/rcodesign.yml
+++ b/.github/workflows/rcodesign.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       actions_ref: "aacf4321e814ace18fe44ef5b8ae213c7b13e460"
       bin: rcodesign
+      extra_build_args_linux_gnu: '--all-features'
       extra_build_args_macos: '--all-features'
       extra_build_args_windows: '--all-features'
       just_bootstrap: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "chrono",
  "clap",
  "cryptographic-message-syntax",
+ "cryptoki",
  "der 0.7.10",
  "dialoguer",
  "difference",
@@ -1284,6 +1285,29 @@ dependencies = [
  "ring",
  "signature 2.2.0",
  "x509-certificate",
+]
+
+[[package]]
+name = "cryptoki"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781357a7779a8e92ea985121bbf379a9adf0777f44ab6392efc6abd5aa9b67db"
+dependencies = [
+ "bitflags 1.3.2",
+ "cryptoki-sys",
+ "libloading",
+ "log",
+ "paste",
+ "secrecy",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753e27d860277930ae9f394c119c8c70303236aab0ffab1d51f3d207dbb2bc4b"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -2827,6 +2851,12 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"

--- a/apple-codesign/Cargo.toml
+++ b/apple-codesign/Cargo.toml
@@ -85,6 +85,7 @@ yubikey = { version = "0.8.0", optional = true, features = ["untested"] }
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zip = { version = "2.4.2", default-features = false, features = ["deflate"] }
 zip_structs = "0.2.1"
+cryptoki = { version = "0.10.0", optional = true }
 
 [dependencies.app-store-connect]
 path = "../app-store-connect"
@@ -129,3 +130,4 @@ notarize = [
     "aws-smithy-types",
 ]
 smartcard = ["yubikey"]
+pkcs11 = ["cryptoki"]

--- a/apple-codesign/docs/apple_codesign.rst
+++ b/apple-codesign/docs/apple_codesign.rst
@@ -57,6 +57,7 @@ to be used as a standalone project.
    apple_codesign_getting_started
    apple_codesign_rcodesign
    apple_codesign_certificate_management
+   apple_codesign_pkcs11
    apple_codesign_smartcard
    apple_codesign_github_actions
    apple_codesign_concepts

--- a/apple-codesign/docs/apple_codesign_pkcs11.rst
+++ b/apple-codesign/docs/apple_codesign_pkcs11.rst
@@ -1,0 +1,165 @@
+.. _apple_codesign_pkcs11:
+
+=====================
+PKCS#11 (HSM) Support
+=====================
+
+This project supports integration with PKCS#11-compatible Hardware
+Security Modules (HSMs) and software tokens. This enables cryptographic
+signing using certificates and private keys stored in secure hardware,
+such as Amazon CloudHSM or Google Cloud HSM.
+
+PKCS#11 integration is useful for organizations that require
+high-assurance key management and want to keep private keys out of
+software memory.
+
+Cargo Feature
+=============
+
+PKCS#11 integration requires the optional and disabled-by-default
+`pkcs11` Cargo feature to be enabled:
+
+.. code-block:: shell
+
+    cargo build --features pkcs11
+
+Supported Devices
+=================
+
+Any device or software that provides a PKCS#11 interface should work. This includes:
+
+- Amazon CloudHSM
+- Google Cloud HSM
+- SoftHSM (for testing)
+
+You will need the vendor's PKCS#11 library (e.g.,
+``/opt/cloudhsm/lib/libcloudhsm_pkcs11.so`` for Amazon, or the path
+provided by Google for Cloud HSM).
+
+Amazon CloudHSM Example
+=======================
+
+1. Ensure your `CloudHSM cluster is initialized <https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-hsm.html>`_ and you have a user and key/certificate loaded.
+2. Set up the `CloudHSM client <https://docs.aws.amazon.com/cloudhsm/latest/userguide/gs_cloudhsm_cli-install.html>`_.
+3. Install the `PKCS#11 library <https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-library-install.html>`_, and note the path to the PKCS#11 library (usually ``/opt/cloudhsm/lib/libcloudhsm_pkcs11.so``).
+4. Sign a file using the certificate file issued by Apple:
+
+.. code-block:: shell
+
+    rcodesign sign \
+        --pkcs11-library /opt/cloudhsm/lib/libcloudhsm_pkcs11.so \
+        --pkcs11-pin <USER:PASS> \
+        --pkcs11-certificate-file /path/to/cert.pem \
+        --pkcs11-key-label <KEY_LABEL> \
+        --code-signature-flags runtime \
+        <file-to-sign>
+
+Google Cloud HSM Example
+========================
+
+1. Set up your Google Cloud HSM and `install the PKCS#11 library <https://cloud.google.com/kms/docs/reference/pkcs11-library>`_.
+2. Ensure your key and certificate are loaded and note their labels or IDs.
+3. Configure the `YAML file <https://github.com/GoogleCloudPlatform/kms-integrations/blob/master/kmsp11/docs/user_guide.md#per-token-configuration>`_.
+4. Set up environment variables to point to your Google credentials and configuration file. For example:
+
+.. code-block:: shell
+
+    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/google-credentials.json
+    export KMS_PKCS11_CONFIG=/path/to/config.yaml
+
+5. Sign a file using the certificate file issued by Apple:
+
+.. code-block:: shell
+
+    rcodesign sign \
+        --pkcs11-library /path/to/google/pkcs11.so \
+        --pkcs11-pin <USER_PIN> \
+        --pkcs11-certificate-file /path/to/cert.pem \
+        --pkcs11-key-label <KEY_LABEL> \
+        --code-signature-flags runtime \
+        <file-to-sign>
+
+Testing with SoftHSM
+====================
+
+For development and testing, you can use SoftHSM:
+
+1. Install the required packages. On Ubuntu or Debian systems:
+
+.. code-block:: shell
+
+    apt update && apt install -y softhsm2 openssl opensc
+
+2. Configure SoftHSM:
+
+.. code-block:: shell
+
+    # Arbitrary PIN values
+    export PKCS11_SO_PIN=123456
+    export PKCS11_PIN=123456
+
+    # Initialize token
+    softhsm2-util --init-token --slot 0 --label "CodeSigning" --so-pin $PKCS11_SO_PIN --pin $PKCS11_PIN
+
+    # List tokens to verify setup
+    softhsm2-util --show-slots
+
+    # Get the slot ID of the initialized token (with label "CodeSigning")
+    export SLOT_ID=$(softhsm2-util --show-slots | awk '/^Slot [0-9]/ {slot=$2} /Label:.*CodeSigning/ {print slot; exit}')
+    echo "Using slot ID: $SLOT_ID"
+
+3. Create test certificate and private key:
+
+.. code-block:: shell
+
+    # Arbitrary name for the key in SoftHSM
+    export KEY_LABEL=mykey
+
+    # Generate a private key
+    openssl genrsa -out private_key.pem 2048
+
+    # Create a self-signed certificate (for testing)
+    openssl req -new -x509 -key private_key.pem -out test_cert.pem -days 365 -subj "/CN=Test Code Signing/O=Test Organization/C=US"
+
+    # Convert certificate to DER format (what PKCS#11 expects)
+    openssl x509 -in test_cert.pem -outform DER -out developerID_application.cer
+
+    # Import certificate
+    pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
+        --login --pin $PKCS11_PIN \
+        --slot $SLOT_ID \
+        --write-object developerID_application.cer \
+        --type cert \
+        --label "cert"
+
+    # Import private key
+    pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
+        --login --pin $PKCS11_PIN \
+        --slot $SLOT_ID \
+        --write-object private_key.pem \
+        --type privkey \
+        --label $KEY_LABEL
+
+4. Sign a file using the test certificate:
+
+.. code-block:: shell
+
+    # Use rcodesign with SoftHSM's PKCS#11 library
+    rcodesign sign \
+        --pkcs11-library /usr/lib/softhsm/libsofthsm2.so \
+        --pkcs11-certificate-file developerID_application.cer \
+        --pkcs11-key-label $KEY_LABEL \
+        --pkcs11-slot-id $SLOT_ID \
+        --pkcs11-pin $PKCS11_PIN \
+        --code-signature-flags runtime \
+        <file-to-sign>
+
+Limitations
+===========
+
+- You must know the correct label or ID for your key in the HSM, and
+  have the certificate file available (unless you have imported the
+  certificate into the HSM, which is uncommon).
+- Some HSMs require additional configuration or environment variables.
+- Only signing is supported; key generation and import must be done
+  using vendor tools.

--- a/apple-codesign/src/cli/certificate_source.rs
+++ b/apple-codesign/src/cli/certificate_source.rs
@@ -28,6 +28,14 @@ use {
     std::str::FromStr,
 };
 
+#[cfg(feature = "pkcs11")]
+use {
+    crate::pkcs11::Pkcs11PrivateKey,
+    cryptoki::{
+        context::{CInitializeArgs, Pkcs11},
+    },
+};
+
 #[cfg(target_os = "macos")]
 use crate::macos::{keychain_find_code_signing_certificates, KeychainDomain};
 
@@ -635,6 +643,10 @@ pub struct CertificateSource {
     pub p12_key: Option<P12SigningKey>,
 
     #[command(flatten)]
+    #[serde(default, rename = "pkcs11", skip_serializing_if = "Option::is_none")]
+    pub pkcs11_key: Option<Pkcs11SigningKey>,
+
+    #[command(flatten)]
     #[serde(default, rename = "remote", skip_serializing_if = "Option::is_none")]
     pub remote_signing_key: Option<RemoteSigningKey>,
 
@@ -674,6 +686,10 @@ impl CertificateSource {
             res.push(key as &dyn KeySource);
         }
 
+        if let Some(key) = &self.pkcs11_key {
+            res.push(key as &dyn KeySource);
+        }
+
         if let Some(key) = &self.remote_signing_key {
             res.push(key as &dyn KeySource);
         }
@@ -703,4 +719,200 @@ impl CertificateSource {
 
         Ok(res)
     }
+}
+
+#[derive(Args, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Pkcs11SigningKey {
+    /// Path to PKCS11 library (.so/.dylib/.dll)
+    #[arg(long = "pkcs11-library", value_name = "PATH")]
+    pub library_path: Option<PathBuf>,
+
+    /// PKCS11 token label to use
+    #[arg(long = "pkcs11-token-label", value_name = "LABEL")]
+    pub token_label: Option<String>,
+
+    /// PKCS11 slot ID to use (alternative to token label)
+    #[arg(long = "pkcs11-slot-id", value_name = "ID")]
+    pub slot_id: Option<u64>,
+
+    /// PIN for PKCS11 token
+    #[arg(long = "pkcs11-pin", value_name = "SECRET")]
+    pub pkcs11_pin: Option<String>,
+
+    /// Environment variable holding the PKCS11 PIN
+    #[arg(long = "pkcs11-pin-env", value_name = "STRING")]
+    #[serde(skip)]
+    pub pkcs11_pin_env: Option<String>,
+
+    /// Path to certificate file (PEM/DER)
+    #[arg(long = "pkcs11-certificate-file", value_name = "PATH")]
+    pub certificate_file: Option<PathBuf>,
+
+    /// Private key label in PKCS11 token (CKA_LABEL attribute)
+    #[arg(long = "pkcs11-key-label", value_name = "LABEL")]
+    pub key_label: Option<String>,
+
+    /// Private key ID in PKCS11 token (CKA_ID attribute)
+    #[arg(long = "pkcs11-key-id", value_name = "ID")]
+    pub key_id: Option<String>,
+}
+
+impl KeySource for Pkcs11SigningKey {
+    #[cfg(feature = "pkcs11")]
+    fn resolve_certificates(&self) -> Result<SigningCertificates, AppleCodesignError> {
+        let library_path = match &self.library_path {
+            Some(path) => path.clone(),
+            None => return Ok(Default::default()),
+        };
+
+        info!("initializing PKCS11 library: {}", library_path.display());
+
+        let pkcs11 = Pkcs11::new(library_path.clone())?;
+        pkcs11.initialize(CInitializeArgs::OsThreads).or_else(|e| {
+            match e {
+                cryptoki::error::Error::AlreadyInitialized => {
+                    info!("PKCS11 library already initialized");
+                    Ok(())
+                }
+                _ => Err(e),
+            }
+        })?;
+
+        let slots = pkcs11.get_slots_with_token()?;
+        if slots.is_empty() {
+            return Err(AppleCodesignError::Pkcs11Error("no PKCS11 tokens found".into()));
+        }
+
+        // Find the right slot
+        let slot = if let Some(slot_id) = self.slot_id {
+            slots.into_iter()
+                .find(|s| s.id() == slot_id)
+                .ok_or_else(|| AppleCodesignError::Pkcs11Error(format!("PKCS11 slot {} not found", slot_id)))?
+        } else if let Some(token_label) = &self.token_label {
+            let target_label = token_label.trim();
+            slots.into_iter()
+                .find(|slot| {
+                    if let Ok(token_info) = pkcs11.get_token_info(*slot) {
+                        let label = String::from_utf8_lossy(&token_info.label().as_bytes()).trim().to_string();
+                        label == target_label
+                    } else {
+                        false
+                    }
+                })
+                .ok_or_else(|| AppleCodesignError::Pkcs11Error(format!("PKCS11 token '{}' not found", target_label)))?
+        } else {
+            slots[0] // Use first slot if no preference specified
+        };
+
+        info!("using PKCS11 slot: {}", slot.id());
+
+        // Load certificate from local file
+        let cert = if let Some(cert_file) = &self.certificate_file {
+            // Load certificate from local file (similar to osslsigncode)
+            info!("loading certificate from local file: {}", cert_file.display());
+            self.load_certificate_from_file(cert_file)?
+        } else {
+            return Err(AppleCodesignError::Pkcs11Error(
+                "--pkcs11-certificate-file is required for Apple code signing workflows".into()
+            ));
+        };
+
+        info!("loaded certificate: {}", cert.subject_common_name().unwrap_or_else(|| "unknown".into()));
+
+        // Create PKCS11 private key wrapper
+        let pkcs11_key = if let Some(key_id) = &self.key_id {
+            // Use CKA_ID attribute
+            Pkcs11PrivateKey::new_with_id(
+                library_path,
+                slot.id(),
+                key_id.clone(),
+                self.get_pin()?,
+                cert.clone(),
+            )?
+        } else if let Some(key_label) = &self.key_label {
+            // Use CKA_LABEL attribute
+            Pkcs11PrivateKey::new_with_label(
+                library_path,
+                slot.id(),
+                key_label.clone(),
+                self.get_pin()?,
+                cert.clone(),
+            )?
+        } else {
+            // Try to find private key automatically based on certificate
+            info!("attempting automatic private key discovery");
+            Pkcs11PrivateKey::new_from_certificate(
+                library_path,
+                slot.id(),
+                self.get_pin()?,
+                cert.clone(),
+            )?
+        };
+
+        Ok(SigningCertificates {
+            keys: vec![Box::new(pkcs11_key)],
+            certs: vec![cert],
+        })
+    }
+
+    #[cfg(not(feature = "pkcs11"))]
+    fn resolve_certificates(&self) -> Result<SigningCertificates, AppleCodesignError> {
+        if self.library_path.is_some() {
+            error!("PKCS11 support not available; ignoring --pkcs11-* arguments");
+        }
+        Ok(Default::default())
+    }
+}
+
+#[cfg(feature = "pkcs11")]
+impl Pkcs11SigningKey {
+    fn get_pin(&self) -> Result<Option<String>, AppleCodesignError> {
+        if let Some(pin) = &self.pkcs11_pin {
+            Ok(Some(pin.clone()))
+        } else if let Some(pin_env) = &self.pkcs11_pin_env {
+            match std::env::var(pin_env) {
+                Ok(pin) => {
+                    info!("using PIN from {} environment variable", pin_env);
+                    Ok(Some(pin))
+                }
+                Err(_) => {
+                    error!("failed to read PIN from environment variable: {}", pin_env);
+                    Err(AppleCodesignError::Pkcs11Error(format!(
+                        "PIN environment variable {} not found", pin_env
+                    )))
+                }
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn load_certificate_from_file(&self, cert_file: &PathBuf) -> Result<CapturedX509Certificate, AppleCodesignError> {
+        let cert_data = std::fs::read(cert_file)?;
+
+        // Try PEM first
+        if let Ok(pem) = pem::parse(&cert_data) {
+            if pem.tag() == "CERTIFICATE" {
+                return CapturedX509Certificate::from_der(pem.contents()).map_err(|e| {
+                    AppleCodesignError::Pkcs11Error(format!(
+                        "failed to parse PEM certificate from file {}: {}",
+                        cert_file.display(),
+                        e
+                    ))
+                });
+            }
+        }
+
+        // Try DER
+        CapturedX509Certificate::from_der(cert_data).map_err(|e| {
+            AppleCodesignError::Pkcs11Error(format!(
+                "failed to parse certificate from file {}: {}",
+                cert_file.display(),
+                e
+            ))
+        })
+    }
+
+
 }

--- a/apple-codesign/src/error.rs
+++ b/apple-codesign/src/error.rs
@@ -368,6 +368,9 @@ pub enum AppleCodesignError {
     #[error("zip structs error: {0}")]
     ZipStructs(#[from] zip_structs::zip_error::ZipReadError),
 
+    #[error("PKCS11 error: {0}")]
+    Pkcs11Error(String),
+
     #[error("remote signing error: {0}")]
     RemoteSign(#[from] RemoteSignError),
 

--- a/apple-codesign/src/lib.rs
+++ b/apple-codesign/src/lib.rs
@@ -167,3 +167,6 @@ pub use verify::*;
 pub mod windows;
 #[cfg(feature = "yubikey")]
 pub mod yubikey;
+
+#[cfg(feature = "pkcs11")]
+pub mod pkcs11;

--- a/apple-codesign/src/pkcs11.rs
+++ b/apple-codesign/src/pkcs11.rs
@@ -1,0 +1,490 @@
+use {
+    crate::{
+        cryptography::{DigestType, PrivateKey},
+        remote_signing::{session_negotiation::PublicKeyPeerDecrypt, RemoteSignError},
+        AppleCodesignError,
+    },
+    bcder::{encode::Values, OctetString},
+    bytes::Bytes,
+    cryptoki::{
+        context::{CInitializeArgs, Pkcs11},
+        mechanism::{Mechanism, MechanismType},
+        object::{Attribute, AttributeType, ObjectClass, ObjectHandle},
+        session::UserType,
+        types::AuthPin,
+    },
+    log::{info, warn},
+    signature::Signer,
+    std::{collections::HashMap, path::PathBuf},
+    x509_certificate::{
+        rfc3447::DigestInfo, CapturedX509Certificate, DigestAlgorithm, KeyAlgorithm, KeyInfoSigner,
+        Sign, Signature, SignatureAlgorithm, X509CertificateError,
+    },
+    zeroize::Zeroizing,
+};
+
+pub struct Pkcs11PrivateKey {
+    library_path: PathBuf,
+    slot_id: u64,
+    key_reference: KeyReference,
+    pin: Option<String>,
+    certificate: CapturedX509Certificate,
+}
+
+/// Reference to a private key in the PKCS11 token
+#[derive(Clone, Debug)]
+pub enum KeyReference {
+    /// Direct object handle (for traditional PKCS11 tokens)
+    Handle(ObjectHandle),
+    /// Key identified by CKA_LABEL attribute
+    Label(String),
+    /// Key identified by CKA_ID attribute
+    Id(String),
+    /// Automatically discover key based on certificate
+    FromCertificate,
+}
+
+impl Pkcs11PrivateKey {
+    pub fn new(
+        library_path: PathBuf,
+        slot_id: u64,
+        key_reference: KeyReference,
+        pin: Option<String>,
+        certificate: CapturedX509Certificate,
+    ) -> Result<Self, AppleCodesignError> {
+        Ok(Self {
+            library_path,
+            slot_id,
+            key_reference,
+            pin,
+            certificate,
+        })
+    }
+
+    pub fn new_with_label(
+        library_path: PathBuf,
+        slot_id: u64,
+        key_label: String,
+        pin: Option<String>,
+        certificate: CapturedX509Certificate,
+    ) -> Result<Self, AppleCodesignError> {
+        Ok(Self {
+            library_path,
+            slot_id,
+            key_reference: KeyReference::Label(key_label),
+            pin,
+            certificate,
+        })
+    }
+
+    pub fn new_with_id(
+        library_path: PathBuf,
+        slot_id: u64,
+        key_id: String,
+        pin: Option<String>,
+        certificate: CapturedX509Certificate,
+    ) -> Result<Self, AppleCodesignError> {
+        Ok(Self {
+            library_path,
+            slot_id,
+            key_reference: KeyReference::Id(key_id),
+            pin,
+            certificate,
+        })
+    }
+
+    pub fn new_from_certificate(
+        library_path: PathBuf,
+        slot_id: u64,
+        pin: Option<String>,
+        certificate: CapturedX509Certificate,
+    ) -> Result<Self, AppleCodesignError> {
+        Ok(Self {
+            library_path,
+            slot_id,
+            key_reference: KeyReference::FromCertificate,
+            pin,
+            certificate,
+        })
+    }
+
+    fn with_session<T, F>(&self, f: F) -> Result<T, AppleCodesignError>
+    where
+        F: FnOnce(&cryptoki::session::Session) -> Result<T, AppleCodesignError>,
+    {
+        let pkcs11 = Pkcs11::new(&self.library_path)?;
+        pkcs11
+            .initialize(CInitializeArgs::OsThreads)
+            .or_else(|e| match e {
+                cryptoki::error::Error::AlreadyInitialized => Ok(()),
+                _ => Err(e),
+            })?;
+
+        let slots = pkcs11.get_slots_with_token()?;
+        let slot = slots
+            .into_iter()
+            .find(|s| s.id() == self.slot_id)
+            .ok_or_else(|| {
+                AppleCodesignError::Pkcs11Error(format!("PKCS11 slot {} not found", self.slot_id))
+            })?;
+
+        let session = pkcs11.open_rw_session(slot)?;
+
+        if let Some(pin) = &self.pin {
+            session.login(UserType::User, Some(&AuthPin::new(pin.clone())))?;
+        }
+
+        let result = f(&session)?;
+
+        // Session will be automatically closed when dropped
+        Ok(result)
+    }
+
+    fn sign_data_with_mechanism(
+        &self,
+        data: &[u8],
+        mechanism: MechanismType,
+    ) -> Result<Vec<u8>, AppleCodesignError> {
+        let mech = match mechanism {
+            MechanismType::ECDSA => Mechanism::Ecdsa,
+            MechanismType::RSA_PKCS => Mechanism::RsaPkcs,
+            MechanismType::RSA_PKCS_PSS => {
+                warn!("RSA PSS requested but using basic RSA PKCS for simplicity");
+                Mechanism::RsaPkcs
+            }
+            _ => {
+                return Err(AppleCodesignError::Pkcs11Error(format!(
+                    "Unsupported mechanism: {:?}",
+                    mechanism
+                )))
+            }
+        };
+        self.with_session(|session| {
+            // Find the private key for signing
+            let key_handle = match &self.key_reference {
+                KeyReference::Handle(handle) => *handle,
+                KeyReference::Label(label) => self.find_private_key_by_label(session, label)?,
+                KeyReference::Id(id) => self.find_private_key_by_id(session, id)?,
+                KeyReference::FromCertificate => self.find_private_key_for_certificate(session)?,
+            };
+
+            let signature = session.sign(&mech, key_handle, data)?;
+            Ok(signature)
+        })
+    }
+
+    fn find_private_key_by_label(
+        &self,
+        session: &cryptoki::session::Session,
+        label: &str,
+    ) -> Result<ObjectHandle, AppleCodesignError> {
+        let template = vec![
+            Attribute::Class(ObjectClass::PRIVATE_KEY),
+            Attribute::Label(label.as_bytes().to_vec()),
+            Attribute::Sign(true),
+        ];
+
+        let objects = session.find_objects(&template)?;
+
+        if objects.is_empty() {
+            return Err(AppleCodesignError::Pkcs11Error(format!(
+                "private key with CKA_LABEL '{}' not found in PKCS11 token",
+                label
+            )));
+        }
+
+        Ok(objects[0])
+    }
+
+    fn find_private_key_by_id(
+        &self,
+        session: &cryptoki::session::Session,
+        id: &str,
+    ) -> Result<ObjectHandle, AppleCodesignError> {
+        // Handle potential hex-encoding that some PKCS11 tools use
+        let id_bytes = hex::decode(id).unwrap_or_else(|_| id.as_bytes().to_vec());
+
+        let template = vec![
+            Attribute::Class(ObjectClass::PRIVATE_KEY),
+            Attribute::Id(id_bytes),
+            Attribute::Sign(true),
+        ];
+
+        let objects = session.find_objects(&template)?;
+
+        if objects.is_empty() {
+            return Err(AppleCodesignError::Pkcs11Error(format!(
+                "private key with CKA_ID '{}' not found in PKCS11 token",
+                id
+            )));
+        }
+
+        Ok(objects[0])
+    }
+
+    fn find_private_key_for_certificate(
+        &self,
+        session: &cryptoki::session::Session,
+    ) -> Result<ObjectHandle, AppleCodesignError> {
+        // Strategy 1: Try to find a private key with the same CKA_LABEL as the certificate
+        if let Ok(cert_attrs) = self.get_certificate_attributes(session) {
+            if let Some(cert_label) = cert_attrs.get(&AttributeType::Label) {
+                if let Attribute::Label(label_bytes) = cert_label {
+                    let label = String::from_utf8_lossy(label_bytes);
+                    if let Ok(key_handle) = self.find_private_key_by_label(session, &label) {
+                        info!("found private key using certificate's CKA_LABEL: {}", label);
+                        return Ok(key_handle);
+                    }
+                }
+            }
+
+            // Strategy 2: Try to find a private key with the same CKA_ID as the certificate
+            if let Some(cert_id) = cert_attrs.get(&AttributeType::Id) {
+                if let Attribute::Id(id_bytes) = cert_id {
+                    let id = String::from_utf8_lossy(id_bytes);
+                    if let Ok(key_handle) = self.find_private_key_by_id(session, &id) {
+                        info!("found private key using certificate's CKA_ID");
+                        return Ok(key_handle);
+                    }
+                }
+            }
+        }
+
+        // Strategy 3: Find any signing-capable private key
+        // This works with simple PKCS11 setups that have only one signing key
+        warn!("certificate not found in PKCS11 token or no matching key attributes, searching for any signing-capable private key");
+
+        let template = vec![
+            Attribute::Class(ObjectClass::PRIVATE_KEY),
+            Attribute::Sign(true),
+        ];
+
+        let objects = session.find_objects(&template)?;
+
+        if objects.is_empty() {
+            return Err(AppleCodesignError::Pkcs11Error(
+                "no signing-capable private key found in PKCS11 token".into(),
+            ));
+        }
+
+        if objects.len() > 1 {
+            warn!("multiple private keys found, using the first one. Consider specifying --pkcs11-key-label or --pkcs11-key-id for precision");
+        }
+
+        Ok(objects[0])
+    }
+
+    fn get_certificate_attributes(
+        &self,
+        session: &cryptoki::session::Session,
+    ) -> Result<HashMap<AttributeType, Attribute>, AppleCodesignError> {
+        // Try to find the certificate in the token by its DER content
+        let template = vec![
+            Attribute::Class(ObjectClass::CERTIFICATE),
+            Attribute::Value(self.certificate.constructed_data().to_vec()),
+        ];
+
+        let objects = session.find_objects(&template)?;
+
+        if objects.is_empty() {
+            // Certificate not found in token--this is OK if loaded from file
+            return Err(AppleCodesignError::Pkcs11Error(
+                "certificate not found in PKCS11 token (normal if certificate was loaded from file)".into()
+            ));
+        }
+
+        let cert_handle = objects[0];
+        let attrs =
+            session.get_attributes(cert_handle, &[AttributeType::Label, AttributeType::Id])?;
+
+        let mut attr_map = HashMap::new();
+        for attr in attrs {
+            attr_map.insert(attr.attribute_type(), attr);
+        }
+
+        Ok(attr_map)
+    }
+
+    pub fn certificate(&self) -> &CapturedX509Certificate {
+        &self.certificate
+    }
+
+    pub fn slot_id(&self) -> u64 {
+        self.slot_id
+    }
+
+    pub fn key_reference(&self) -> &KeyReference {
+        &self.key_reference
+    }
+}
+
+impl Clone for Pkcs11PrivateKey {
+    fn clone(&self) -> Self {
+        Self {
+            library_path: self.library_path.clone(),
+            slot_id: self.slot_id,
+            key_reference: self.key_reference.clone(),
+            pin: self.pin.clone(),
+            certificate: self.certificate.clone(),
+        }
+    }
+}
+
+impl Signer<Signature> for Pkcs11PrivateKey {
+    fn try_sign(&self, message: &[u8]) -> Result<Signature, signature::Error> {
+        // Use the certificate's key algorithm, not signature algorithm (which is from the CA)
+        let key_algorithm = self.certificate.key_algorithm().ok_or_else(|| {
+            signature::Error::from_source("Cannot determine key algorithm from certificate")
+        })?;
+
+        info!("Certificate key algorithm: {:?}", key_algorithm);
+
+        let (mechanism, input) = match key_algorithm {
+            KeyAlgorithm::Ecdsa(_) => {
+                let hashed_data = DigestType::Sha256
+                    .digest_data(message)
+                    .map_err(signature::Error::from_source)?;
+                (MechanismType::ECDSA, hashed_data)
+            }
+            KeyAlgorithm::Rsa => {
+                // Some PKCS11 modules, such as Google Cloud HSM, claim to support SHA256_RSA_PKCS
+                // but attempting to use it returns "Unsupported mechanism: MechanismType { val: 64 }".
+                // Use the least common denominator with RSA_PKCS.
+                let digest = DigestAlgorithm::Sha256.digest_data(message);
+
+                // Unfortunately we can't use x509_certificate::rsa_pkcs1_encode() here because it
+                // implements CKM_RSA_X_509 instead of CKM_RSA_PKCS.
+                // CKM_RSA_X_509 implements the full padding procedure described in https://tools.ietf.org/html/rfc3447#section-9.2:
+                //
+                // For 2048-bit RSA (256 bytes total):
+                // Byte 0:     0x00                    (header)
+                // Byte 1:     0x01                    (signature block type)
+                // Bytes 2-X:  0xFF 0xFF 0xFF ...      (padding, ~205 bytes)
+                // Byte X+1:   0x00                    (null terminator)
+                // Bytes X+2+: 30 31 30 0d ... hash    (DigestInfo, ~51 bytes)
+                //
+                // CKM_RSA_PKCS expects the input to be the DigestInfo, with the header, block type, and
+                // padding omitted.
+                let digest_info = DigestInfo {
+                    algorithm: DigestAlgorithm::Sha256.into(),
+                    digest: OctetString::new(digest.into()),
+                };
+
+                let mut digest_info_der = vec![];
+                digest_info
+                    .write_encoded(bcder::Mode::Der, &mut digest_info_der)
+                    .map_err(signature::Error::from_source)?;
+
+                (MechanismType::RSA_PKCS, digest_info_der)
+            }
+            _ => {
+                return Err(signature::Error::from_source(format!(
+                    "Unsupported key algorithm for PKCS11: {:?}",
+                    key_algorithm
+                )))
+            }
+        };
+
+        let signature_bytes = self
+            .sign_data_with_mechanism(&input, mechanism)
+            .map_err(signature::Error::from_source)?;
+
+        Ok(Signature::from(signature_bytes))
+    }
+}
+
+impl KeyInfoSigner for Pkcs11PrivateKey {}
+
+impl Sign for Pkcs11PrivateKey {
+    fn sign(&self, message: &[u8]) -> Result<(Vec<u8>, SignatureAlgorithm), X509CertificateError> {
+        let algorithm = self.signature_algorithm()?;
+
+        let mechanism = match algorithm {
+            SignatureAlgorithm::EcdsaSha256 => MechanismType::ECDSA,
+            SignatureAlgorithm::RsaSha256 => MechanismType::RSA_PKCS,
+            _ => {
+                return Err(X509CertificateError::Other(format!(
+                    "Unsupported signature algorithm for PKCS11: {:?}",
+                    algorithm
+                )))
+            }
+        };
+
+        let signature = self
+            .sign_data_with_mechanism(message, mechanism)
+            .map_err(|e| X509CertificateError::Other(format!("PKCS11 signing error: {}", e)))?;
+
+        Ok((signature, algorithm))
+    }
+
+    fn key_algorithm(&self) -> Option<KeyAlgorithm> {
+        self.certificate.key_algorithm()
+    }
+
+    fn public_key_data(&self) -> Bytes {
+        self.certificate.public_key_data()
+    }
+
+    fn signature_algorithm(&self) -> Result<SignatureAlgorithm, X509CertificateError> {
+        self.certificate.signature_algorithm().ok_or(
+            X509CertificateError::UnknownSignatureAlgorithm(format!(
+                "{:?}",
+                self.certificate.signature_algorithm_oid()
+            )),
+        )
+    }
+
+    fn private_key_data(&self) -> Option<Zeroizing<Vec<u8>>> {
+        // PKCS11 providers never expose private key data
+        None
+    }
+
+    fn rsa_primes(
+        &self,
+    ) -> Result<Option<(Zeroizing<Vec<u8>>, Zeroizing<Vec<u8>>)>, X509CertificateError> {
+        // PKCS11 providers never expose RSA prime factors
+        Ok(None)
+    }
+}
+
+impl PublicKeyPeerDecrypt for Pkcs11PrivateKey {
+    fn decrypt(&self, _ciphertext: &[u8]) -> Result<Vec<u8>, RemoteSignError> {
+        // For RSA keys, we could potentially support decryption
+        match self.certificate.key_algorithm() {
+            Some(KeyAlgorithm::Rsa) => {
+                // Could implement RSA decryption here if needed
+                Err(RemoteSignError::Crypto(
+                    "RSA decryption via PKCS11 not yet implemented".into(),
+                ))
+            }
+            _ => Err(RemoteSignError::Crypto(
+                "decryption only supported for RSA keys".into(),
+            )),
+        }
+    }
+}
+
+impl PrivateKey for Pkcs11PrivateKey {
+    fn as_key_info_signer(&self) -> &dyn KeyInfoSigner {
+        self
+    }
+
+    fn to_public_key_peer_decrypt(
+        &self,
+    ) -> Result<Box<dyn PublicKeyPeerDecrypt>, AppleCodesignError> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn finish(&self) -> Result<(), AppleCodesignError> {
+        // Could implement cleanup logic here if needed
+        // For now, PKCS11 sessions are cleaned up automatically
+        Ok(())
+    }
+}
+
+// Convert PKCS11 errors to AppleCodesignError
+impl From<cryptoki::error::Error> for AppleCodesignError {
+    fn from(err: cryptoki::error::Error) -> Self {
+        AppleCodesignError::Pkcs11Error(format!("PKCS11 error: {}", err))
+    }
+}

--- a/apple-codesign/tests/cmd/analyze-certificate.trycmd
+++ b/apple-codesign/tests/cmd/analyze-certificate.trycmd
@@ -65,6 +65,30 @@ Options:
       --p12-password-file <PATH>
           Path to file containing password for opening --p12-file file
 
+      --pkcs11-library <PATH>
+          Path to PKCS11 library (.so/.dylib/.dll)
+
+      --pkcs11-token-label <LABEL>
+          PKCS11 token label to use
+
+      --pkcs11-slot-id <ID>
+          PKCS11 slot ID to use (alternative to token label)
+
+      --pkcs11-pin <SECRET>
+          PIN for PKCS11 token
+
+      --pkcs11-pin-env <STRING>
+          Environment variable holding the PKCS11 PIN
+
+      --pkcs11-certificate-file <PATH>
+          Path to certificate file (PEM/DER)
+
+      --pkcs11-key-label <LABEL>
+          Private key label in PKCS11 token (CKA_LABEL attribute)
+
+      --pkcs11-key-id <ID>
+          Private key ID in PKCS11 token (CKA_ID attribute)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/generate-csr.trycmd
+++ b/apple-codesign/tests/cmd/generate-csr.trycmd
@@ -64,6 +64,30 @@ Options:
       --p12-password-file <PATH>
           Path to file containing password for opening --p12-file file
 
+      --pkcs11-library <PATH>
+          Path to PKCS11 library (.so/.dylib/.dll)
+
+      --pkcs11-token-label <LABEL>
+          PKCS11 token label to use
+
+      --pkcs11-slot-id <ID>
+          PKCS11 slot ID to use (alternative to token label)
+
+      --pkcs11-pin <SECRET>
+          PIN for PKCS11 token
+
+      --pkcs11-pin-env <STRING>
+          Environment variable holding the PKCS11 PIN
+
+      --pkcs11-certificate-file <PATH>
+          Path to certificate file (PEM/DER)
+
+      --pkcs11-key-label <LABEL>
+          Private key label in PKCS11 token (CKA_LABEL attribute)
+
+      --pkcs11-key-id <ID>
+          Private key ID in PKCS11 token (CKA_ID attribute)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/remote-sign.trycmd
+++ b/apple-codesign/tests/cmd/remote-sign.trycmd
@@ -71,6 +71,30 @@ Options:
       --p12-password-file <PATH>
           Path to file containing password for opening --p12-file file
 
+      --pkcs11-library <PATH>
+          Path to PKCS11 library (.so/.dylib/.dll)
+
+      --pkcs11-token-label <LABEL>
+          PKCS11 token label to use
+
+      --pkcs11-slot-id <ID>
+          PKCS11 slot ID to use (alternative to token label)
+
+      --pkcs11-pin <SECRET>
+          PIN for PKCS11 token
+
+      --pkcs11-pin-env <STRING>
+          Environment variable holding the PKCS11 PIN
+
+      --pkcs11-certificate-file <PATH>
+          Path to certificate file (PEM/DER)
+
+      --pkcs11-key-label <LABEL>
+          Private key label in PKCS11 token (CKA_LABEL attribute)
+
+      --pkcs11-key-id <ID>
+          Private key ID in PKCS11 token (CKA_ID attribute)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/sign.trycmd
+++ b/apple-codesign/tests/cmd/sign.trycmd
@@ -398,6 +398,30 @@ Options:
       --p12-password-file <PATH>
           Path to file containing password for opening --p12-file file
 
+      --pkcs11-library <PATH>
+          Path to PKCS11 library (.so/.dylib/.dll)
+
+      --pkcs11-token-label <LABEL>
+          PKCS11 token label to use
+
+      --pkcs11-slot-id <ID>
+          PKCS11 slot ID to use (alternative to token label)
+
+      --pkcs11-pin <SECRET>
+          PIN for PKCS11 token
+
+      --pkcs11-pin-env <STRING>
+          Environment variable holding the PKCS11 PIN
+
+      --pkcs11-certificate-file <PATH>
+          Path to certificate file (PEM/DER)
+
+      --pkcs11-key-label <LABEL>
+          Private key label in PKCS11 token (CKA_LABEL attribute)
+
+      --pkcs11-key-id <ID>
+          Private key ID in PKCS11 token (CKA_ID attribute)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/smartcard-import.trycmd
+++ b/apple-codesign/tests/cmd/smartcard-import.trycmd
@@ -67,6 +67,30 @@ Options:
       --p12-password-file <PATH>
           Path to file containing password for opening --p12-file file
 
+      --pkcs11-library <PATH>
+          Path to PKCS11 library (.so/.dylib/.dll)
+
+      --pkcs11-token-label <LABEL>
+          PKCS11 token label to use
+
+      --pkcs11-slot-id <ID>
+          PKCS11 slot ID to use (alternative to token label)
+
+      --pkcs11-pin <SECRET>
+          PIN for PKCS11 token
+
+      --pkcs11-pin-env <STRING>
+          Environment variable holding the PKCS11 PIN
+
+      --pkcs11-certificate-file <PATH>
+          Path to certificate file (PEM/DER)
+
+      --pkcs11-key-label <LABEL>
+          Private key label in PKCS11 token (CKA_LABEL attribute)
+
+      --pkcs11-key-id <ID>
+          Private key ID in PKCS11 token (CKA_ID attribute)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 


### PR DESCRIPTION
This makes it possible to sign macOS binaries with a PKCS#11 module.
This has been tested with Google Cloud HSM and SoftHSM.

Closes #184