### PR TITLE
ci: fix Windows 2022 i686 builds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,7 @@ actions-bootstrap-rust-linux:
 actions-bootstrap-rust-macos:
 
 actions-bootstrap-rust-windows:
+  choco install nasm
 
 # Trigger a workflow on a branch.
 ci-run workflow branch="ci-test":


### PR DESCRIPTION
The CI builds failed with these error messages when compiling the `aws-ls-sys` crate:

```
  -- The ASM_NASM compiler identification is unknown
  -- Didn't find assembler
  -- Configuring incomplete, errors occurred!
<snip>

  CMake Error at aws-lc/crypto/CMakeLists.txt:123 (enable_language):
    No CMAKE_ASM_NASM_COMPILER could be found.
```

As explained in https://github.com/aws/aws-lc-rs/issues/771, this occurs when NASM is not available. Install NASM in the `Justfile` to ensure `aws-lc-sys` can compile.

Closes #208