### PR TITLE
apple-flat-package: Fix Distribution deserialization error

### DIFF
--- a/apple-flat-package/src/distribution.rs
+++ b/apple-flat-package/src/distribution.rs
@@ -319,6 +319,7 @@ pub struct Title {
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename = "kebab-case")]
 pub struct VolumeCheck {
+    #[serde(default)]
     pub script: bool,
     pub allowed_os_versions: Option<AllowedOsVersions>,
     pub required_bundles: Option<RequiredBundles>,


### PR DESCRIPTION
I ran into an error when trying to parse the Distribution file of a pretty barebones flat package built using `productbuild`. The package included only a signed appbundle, with no scripts outside of what `productbuild` could add by default.

Looking into it, I found that `VolumeCheck::script` was missing from the Distribution XML. Since the package is coming from `productbuild`, I'm assuming that it's valid for the variable to not be defined, so its absence shouldn't be treated as an error. 

