### PR TITLE
apple-codesign: Allow building a notarizer from in-memory `UnifiedApiKey`

### DIFF
--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -163,9 +163,14 @@ impl Notarizer {
         )?))
     }
 
+    /// Construct an instance from a [`UnifiedApiKey`].
+    pub fn from_api_key(key: UnifiedApiKey) -> Result<Self, AppleCodesignError> {
+        Ok(Self::new(key.try_into()?))
+    }
+
     /// Construct an instance from a file containing a JSON encoded API key.
-    pub fn from_api_key(path: &Path) -> Result<Self, AppleCodesignError> {
-        Ok(Self::new(UnifiedApiKey::from_json_path(path)?.try_into()?))
+    pub fn from_api_key_file(path: &Path) -> Result<Self, AppleCodesignError> {
+        Self::from_api_key(UnifiedApiKey::from_json_path(path)?)
     }
 
     /// Attempt to notarize an asset defined by a filesystem path.


### PR DESCRIPTION
We have a case where we load the `UnifiedApiKey` as part of another object. There doesn't seem to be any way to create a `Notarizer` from a key that is already in memory - only from a file.

So I've added `Notarizer::from_api_key` to allow that.