### PR TITLE
Allow creating a Signer without mutable ref

### DIFF
--- a/apple-codesign/src/yubikey.rs
+++ b/apple-codesign/src/yubikey.rs
@@ -193,7 +193,7 @@ impl YubiKey {
 
     /// Find certificates in this device.
     pub fn find_certificates(
-        &mut self,
+        &self,
     ) -> Result<Vec<(SlotId, CapturedX509Certificate)>, AppleCodesignError> {
         let mut guard = self.inner()?;
         let yk = guard.deref_mut();
@@ -219,7 +219,7 @@ impl YubiKey {
 
     /// Obtain an entity for creating signatures using a certificate at a slot.
     pub fn get_certificate_signer(
-        &mut self,
+        &self,
         slot_id: SlotId,
     ) -> Result<Option<CertificateSigner>, AppleCodesignError> {
         Ok(self


### PR DESCRIPTION
Currently, creating a Signer requires a mutable reference to a YubiKey, even though that mutable reference is unnecessary due to the use of a mutex. This commit downgrades the mutable reference to an immutable reference in find_certificates and get_certificate_signer.