### PR TITLE
Update bzip2 dependency to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,22 +1022,11 @@ checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -2575,6 +2564,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"

--- a/apple-xar/Cargo.toml
+++ b/apple-xar/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 base64 = "0.22.1"
 bcder = { version = "0.7.5", optional = true }
-bzip2 = "0.4.4"
+bzip2 = "0.6.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 cryptographic-message-syntax = { version = "0.28.0", optional = true }
 digest = "0.10.7"


### PR DESCRIPTION
This is a follow-up to https://github.com/indygreg/apple-platform-rs/pull/181. Version [0.6] “switches to [libbz2-rs-sys](https://github.com/trifectatechfoundation/libbzip2-rs) as the default bzip2 backend. It is written in rust, making it much easier to cross-compile. The new implementation is also more performant.” There should be no API changes from bzip2 0.5.