### PR TITLE
Replace outdated xz2 crate with liblzma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "cryptographic-message-syntax",
  "digest",
  "flate2",
+ "liblzma",
  "log",
  "md-5",
  "rand 0.8.5",
@@ -319,7 +320,6 @@ dependencies = [
  "url",
  "x509-certificate",
  "xml-rs",
- "xz2",
 ]
 
 [[package]]
@@ -2000,6 +2000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2541,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c36d08cad03a3fbe2c4e7bb3a9e84c57e4ee4135ed0b065cade3d98480c648"
+dependencies = [
+ "liblzma-sys",
+ "num_cpus",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,17 +2619,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "md-5"
@@ -2750,6 +2766,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5085,15 +5111,6 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
 
 [[package]]
 name = "yansi"

--- a/apple-xar/Cargo.toml
+++ b/apple-xar/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = "2.0.17"
 url = "2.5.7"
 xml-rs = "1.0.0"
 x509-certificate = "0.25.0"
-xz2 = { version = "0.1.7", features = ["static"] }
+liblzma = { version = "0.4.5", features = ["static", "parallel"] }
 
 [features]
 default = ["signing"]

--- a/apple-xar/src/reader.rs
+++ b/apple-xar/src/reader.rs
@@ -235,7 +235,7 @@ impl<R: Read + Seek + Sized + Debug> XarReader<R> {
             "application/x-gzip" => {
                 Box::new(flate2::write::ZlibDecoder::new(writer)) as Box<dyn Write>
             }
-            "application/x-lzma" => Box::new(xz2::write::XzDecoder::new(writer)) as Box<dyn Write>,
+            "application/x-lzma" => Box::new(liblzma::write::XzDecoder::new(writer)) as Box<dyn Write>,
             encoding => {
                 return Err(Error::UnimplementedFileEncoding(encoding.to_string()));
             }


### PR DESCRIPTION
xz2 crate seems to be unmaintained, having had no commits in 4 years. It looks like the ecosystem is moving towards the [liblzma](https://github.com/portable-network-archive/liblzma-rs) fork (for instance, this is what the [rpm crate uses](https://docs.rs/crate/rpm/latest/features#xz-compression).