### PR TITLE
follow rust ffi requirements

### DIFF
--- a/apple-bom/src/builder.rs
+++ b/apple-bom/src/builder.rs
@@ -220,7 +220,7 @@ impl BomBuilder {
         };
         let file = BomBlockFile {
             parent_path_id: 0,
-            name: Cow::from(CString::new(b".\0".to_vec()).expect("string is null terminated")),
+            name: Cow::from(CString::new(b".".to_vec()).expect("string is null terminated")),
         };
 
         records.push((1u32, path_record, file));
@@ -263,7 +263,6 @@ impl BomBuilder {
 
                 let mut path_cstring = Vec::<u8>::with_capacity(path.len());
                 path_cstring.extend(path.as_bytes());
-                path_cstring.push(0);
                 let path_cstring =
                     CString::new(path_cstring).expect("C string should be well formed");
 
@@ -286,7 +285,6 @@ impl BomBuilder {
 
             let mut path_cstring = Vec::<u8>::with_capacity(path.len() + 1);
             path_cstring.extend(path.as_bytes());
-            path_cstring.push(0);
             let path_cstring = CString::new(path_cstring).expect("should be valid C string");
 
             let path_record = BomBlockPathRecord {

--- a/apple-bom/src/path.rs
+++ b/apple-bom/src/path.rs
@@ -266,8 +266,6 @@ impl BomPath {
         if let Some(link_name) = &self.link_name {
             let mut data = Vec::<u8>::with_capacity(link_name.len() + 1);
             data.extend(link_name.as_bytes());
-            data.push(0);
-
             Some(CString::new(data).expect("should be valid C string"))
         } else {
             None


### PR DESCRIPTION
This patch resolves Rust FFI errors at runtime.

Note that the `cargo test` suite continues to pass with and without this patch. Recommend adding some unit and/or integration tests later, to ensure that this behavior is properly validated.

Meanwhile, users may consume this patch by pointing `Cargo.toml` at it:

```toml
[dependencies]
apple-bom = { git = "https://github.com/mcandre/apple-platform-rs.git", rev = "b2c32eabf733d0f0521d8649cbe18f10dd741c06" }
apple-flat-package = { git = "https://github.com/mcandre/apple-platform-rs.git", rev = "b2c32eabf733d0f0521d8649cbe18f10dd741c06" }
```