### PR TITLE
apply auto_write_dirs control field

### DIFF
--- a/cpio-archive/src/odc.rs
+++ b/cpio-archive/src/odc.rs
@@ -397,6 +397,10 @@ impl<W: Write + Sized> OdcBuilder<W> {
 
         let mut bytes_written = 0;
 
+        if !self.auto_write_dirs {
+            return Ok(bytes_written)
+        }
+
         for idx in 1..parts.len() {
             let dir = parts
                 .clone()


### PR DESCRIPTION
Remember to use the auto_write_dirs field when generating archive entries

Note that the unit tests continue to pass regardless of this change. Recommend introducing a new test to validate.

Closes https://github.com/indygreg/apple-platform-rs/issues/256