### PR TITLE
cpio mode enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,6 @@ name = "cpio-archive"
 version = "0.10.0"
 dependencies = [
  "chrono",
- "is_executable",
  "simple-file-manifest",
  "thiserror 2.0.18",
 ]
@@ -2357,15 +2356,6 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is_executable"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
-dependencies = [
- "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/cpio-archive/Cargo.toml
+++ b/cpio-archive/Cargo.toml
@@ -13,6 +13,5 @@ readme = "README.md"
 
 [dependencies]
 chrono = "0.4.43"
-is_executable = "1.0.5"
 simple-file-manifest = "0.11.0"
 thiserror = "2.0.18"


### PR DESCRIPTION
* Tweak API to distinguish between preserving the mode seen on disk, vs. overriding file/directory modes.
* Prototype a helper function `permissions_to_u32`, as a best effort disk mode loader that compiles for UNIX and nonUNIX targets. I've been copying this logic among a variety of my personal Rust projects. Invited to analyze, just in case I got something wrong there.
* Remove complicated logic concerning executables. A passthrough design is safer, and respects the user's intent. If more advanced logic is needed, consider something resembling chandler, which uses fast, filename based logic instead of waiting to read mimetype data. https://github.com/mcandre/chandler It simply assumes that (.exe files + extensionless files) are executables, and nothing else, unless the user explicitly configures the archival settings otherwise. A modest collection of exceptions are included by default, such as `makefile`, `LICENSE`, `README`, etc.
* Fix ambiguous mode emitted by `append_file_from_path`.
* Update Cargo.lock (recommend redoing with `cargo update` by the author as a security precaution).

`is_detection` is interesting. I wouldn't mind that logic as much, if the cpio builder gained an option to disable it.

Unit tests pass regardless of this change. Recommend introducing additional tests.

Relates to https://github.com/indygreg/apple-platform-rs/issues/255