### PR TITLE
WIP: AWS KMS code signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "apple-flat-package",
  "apple-xar",
  "aws-config",
+ "aws-sdk-kms",
  "aws-sdk-s3",
  "aws-smithy-http",
  "aws-smithy-types",
@@ -474,6 +475,29 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c74fef3d08159467cad98300f33a2e3bd1a985d527ad66ab0ea83c95e3a615"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]

--- a/apple-codesign/Cargo.toml
+++ b/apple-codesign/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 anyhow = "1.0.100"
 aws-config = { version = "1.8.12", optional = true }
 aws-sdk-s3 = { version = "1.120.0", optional = true }
+aws-sdk-kms = { version = "1.98.0", optional = true }
 aws-smithy-http = { version = "0.62.6", optional = true }
 aws-smithy-types = { version = "1.3.6", optional = true }
 base64 = "0.22.1"
@@ -121,7 +122,7 @@ trycmd-indygreg-fork = "0.14.20"
 zip = { version = "7.1.0", default-features = false }
 
 [features]
-default = ["notarize"]
+default = ["notarize", "aws-kms"]
 notarize = [
     "app-store-connect",
     "aws-config",
@@ -131,3 +132,4 @@ notarize = [
 ]
 smartcard = ["yubikey"]
 pkcs11 = ["cryptoki"]
+aws-kms = ["aws-sdk-kms"]

--- a/apple-codesign/src/aws_kms.rs
+++ b/apple-codesign/src/aws_kms.rs
@@ -1,0 +1,228 @@
+//! Using the AWS Key Management Service to sign binaries.
+//! This uses the AWS SDK, which accepts authentication in similar ways to the
+//! CLI: <https://docs.aws.amazon.com/sdkref/latest/guide/access.html>
+//!
+//! Example:
+//! ```text
+//! rcodesign sign --aws-kms-key-id 'arn:aws:kms:us-east-1:123456781234:key/12345678-1234-1234-1234-123456789123' --aws-kms-certificate-file ./cert.pem.crt ./rcodesign
+//! ```
+//!
+//! For testing, you can use a rather annoying key wrapping procedure to
+//! import the keys from `rcodesign generate-self-signed-certificate` to KMS:
+//! <https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-conceptual.html>
+//!
+//! Alternatively, you can create a CSR from the KMS public key and then self
+//! sign it.
+
+use std::sync::Arc;
+
+use aws_config::BehaviorVersion;
+use bcder::{decode::Constructed, Mode};
+use signature::Signer;
+use x509_certificate::{
+    rfc5280::SubjectPublicKeyInfo, EcdsaCurve, KeyAlgorithm, KeyInfoSigner, Sign, Signature,
+    SignatureAlgorithm, X509CertificateError,
+};
+
+use aws_sdk_kms::types::SigningAlgorithmSpec as AWSSigningAlgorithm;
+
+use crate::{cryptography::PrivateKey, AppleCodesignError};
+
+pub struct KMSSigner {
+    pub runtime: tokio::runtime::Runtime,
+    client: aws_sdk_kms::Client,
+}
+
+impl KMSSigner {
+    pub fn new() -> Result<Arc<KMSSigner>, AppleCodesignError> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let config = runtime.block_on(aws_config::load_defaults(BehaviorVersion::v2026_01_12()));
+        let client = aws_sdk_kms::Client::new(&config);
+        Ok(Arc::new(KMSSigner { runtime, client }))
+    }
+}
+
+pub struct AWSKMSKey {
+    signer: Arc<KMSSigner>,
+    public_key_info: SubjectPublicKeyInfo,
+    key_id: String,
+}
+
+impl AWSKMSKey {
+    pub async fn new(
+        signer: Arc<KMSSigner>,
+        key_id: String,
+    ) -> Result<AWSKMSKey, AppleCodesignError> {
+        let pubkey_resp = signer
+            .client
+            .get_public_key()
+            .key_id(&key_id)
+            .send()
+            .await
+            .map_err(|e| {
+                AppleCodesignError::AWSKMSGetPublicKeyError(
+                    aws_smithy_types::error::display::DisplayErrorContext(e).into(),
+                )
+            })?;
+
+        let pubkey = pubkey_resp
+            .public_key
+            .ok_or(AppleCodesignError::AWSKMSError(
+                "missing pubkey in pubkey response".to_owned(),
+            ))?;
+
+        let actual_pubkey =
+            Constructed::decode(pubkey.as_ref(), Mode::Der, SubjectPublicKeyInfo::take_from)
+                .map_err(|e| {
+                    AppleCodesignError::AWSKMSError(format!("Non-decodable DER from AWS?! {}", e))
+                })?;
+
+        Ok(AWSKMSKey {
+            signer,
+            public_key_info: actual_pubkey,
+            key_id,
+        })
+    }
+
+    pub fn public_key_info(&self) -> &SubjectPublicKeyInfo {
+        &self.public_key_info
+    }
+
+    fn choose_signature_algorithm(
+        &self,
+    ) -> Result<(SignatureAlgorithm, AWSSigningAlgorithm), String> {
+        let algorithm = self
+            .key_algorithm()
+            .ok_or_else(|| "Cannot determine key algorithm from certificate".to_owned())?;
+
+        // For reference: <https://github.com/aws-samples/diy-code-signing-kms-private-ca/blob/master/src/main/java/com/amazonaws/acmpcakms/examples/algorithms/ecc/ECP384Family.java>
+        Ok(match algorithm {
+            KeyAlgorithm::Ecdsa(EcdsaCurve::Secp256r1) => (
+                SignatureAlgorithm::EcdsaSha256,
+                AWSSigningAlgorithm::EcdsaSha256,
+            ),
+            KeyAlgorithm::Ecdsa(EcdsaCurve::Secp384r1) => (
+                SignatureAlgorithm::EcdsaSha384,
+                AWSSigningAlgorithm::EcdsaSha384,
+            ),
+            KeyAlgorithm::Rsa => (
+                SignatureAlgorithm::RsaSha256,
+                AWSSigningAlgorithm::RsassaPkcs1V15Sha256,
+            ),
+            _ => {
+                return Err(format!(
+                    "Unsupported key algorithm for AWS KMS: {:?}",
+                    algorithm
+                ))
+            }
+        })
+    }
+}
+
+impl Signer<Signature> for AWSKMSKey {
+    fn try_sign(&self, msg: &[u8]) -> Result<Signature, signature::Error> {
+        let (_alg, aws_algorithm) = self
+            .choose_signature_algorithm()
+            .map_err(signature::Error::from_source)?;
+
+        let sig = self
+            .signer
+            .runtime
+            .block_on(
+                self.signer
+                    .client
+                    .sign()
+                    .key_id(&self.key_id)
+                    .signing_algorithm(aws_algorithm)
+                    .message(msg.into())
+                    .send(),
+            )
+            .map_err(|e| {
+                signature::Error::from_source(AppleCodesignError::AWSKMSSignError(
+                    aws_smithy_types::error::display::DisplayErrorContext(e).into(),
+                ))
+            })?;
+
+        Ok(sig
+            .signature
+            .ok_or(signature::Error::from_source(
+                "AWS KMS gave us no signature. This should not occur".to_owned(),
+            ))?
+            .into_inner()
+            .into())
+    }
+}
+
+impl Sign for AWSKMSKey {
+    fn sign(
+        &self,
+        message: &[u8],
+    ) -> Result<
+        (Vec<u8>, x509_certificate::SignatureAlgorithm),
+        x509_certificate::X509CertificateError,
+    > {
+        // NOTE: This function isn't actually used anywhere AFAIK.
+        let (algorithm, _aws_algorithm) = self
+            .choose_signature_algorithm()
+            .map_err(X509CertificateError::Other)?;
+        Ok((self.try_sign(message)?.into(), algorithm))
+    }
+
+    fn key_algorithm(&self) -> Option<x509_certificate::KeyAlgorithm> {
+        KeyAlgorithm::try_from(&self.public_key_info.algorithm).ok()
+    }
+
+    fn public_key_data(&self) -> bytes::Bytes {
+        self.public_key_info.subject_public_key.octet_bytes()
+    }
+
+    fn signature_algorithm(
+        &self,
+    ) -> Result<x509_certificate::SignatureAlgorithm, x509_certificate::X509CertificateError> {
+        Ok(self
+            .choose_signature_algorithm()
+            .map_err(X509CertificateError::UnknownSignatureAlgorithm)?
+            .0)
+    }
+
+    fn private_key_data(&self) -> Option<zeroize::Zeroizing<Vec<u8>>> {
+        // This is simply not obtainable.
+        None
+    }
+
+    fn rsa_primes(
+        &self,
+    ) -> Result<
+        Option<(zeroize::Zeroizing<Vec<u8>>, zeroize::Zeroizing<Vec<u8>>)>,
+        x509_certificate::X509CertificateError,
+    > {
+        // This is also a private key.
+        Ok(None)
+    }
+}
+
+impl KeyInfoSigner for AWSKMSKey {}
+
+impl PrivateKey for AWSKMSKey {
+    fn as_key_info_signer(&self) -> &dyn x509_certificate::KeyInfoSigner {
+        self
+    }
+
+    fn to_public_key_peer_decrypt(
+        &self,
+    ) -> Result<
+        Box<dyn crate::remote_signing::session_negotiation::PublicKeyPeerDecrypt>,
+        AppleCodesignError,
+    > {
+        Err(AppleCodesignError::AWSKMSError(
+            "Remote signing is not supported with KMS yet".to_owned(),
+        ))
+    }
+
+    fn finish(&self) -> Result<(), AppleCodesignError> {
+        Ok(())
+    }
+}

--- a/apple-codesign/src/aws_kms.rs
+++ b/apple-codesign/src/aws_kms.rs
@@ -14,32 +14,140 @@
 //! Alternatively, you can create a CSR from the KMS public key and then self
 //! sign it.
 
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Read;
+use std::process::Child;
+use std::process::Command;
+use std::process::Stdio;
 use std::sync::Arc;
 
 use aws_config::BehaviorVersion;
 use bcder::{decode::Constructed, Mode};
+use rand::Rng;
 use signature::Signer;
+use tempfile::TempDir;
 use x509_certificate::{
     rfc5280::SubjectPublicKeyInfo, EcdsaCurve, KeyAlgorithm, KeyInfoSigner, Sign, Signature,
     SignatureAlgorithm, X509CertificateError,
 };
 
+use aws_sdk_kms::types::KeySpec as AWSKeySpec;
 use aws_sdk_kms::types::SigningAlgorithmSpec as AWSSigningAlgorithm;
 
 use crate::{cryptography::PrivateKey, AppleCodesignError};
+
+fn key_algorithm_to_aws(key_alg: KeyAlgorithm) -> AWSKeySpec {
+    match key_alg {
+        KeyAlgorithm::Rsa => AWSKeySpec::Rsa2048,
+        KeyAlgorithm::Ecdsa(EcdsaCurve::Secp256r1) => AWSKeySpec::EccNistP256,
+        KeyAlgorithm::Ecdsa(EcdsaCurve::Secp384r1) => AWSKeySpec::EccNistP384,
+        KeyAlgorithm::Ed25519 => AWSKeySpec::EccNistEdwards25519,
+    }
+}
 
 pub struct KMSSigner {
     pub runtime: tokio::runtime::Runtime,
     client: aws_sdk_kms::Client,
 }
 
+pub struct TestKMSSigner {
+    process: Child,
+    _stderr_logger: std::thread::JoinHandle<()>,
+    #[allow(dead_code)]
+    tmpdir: TempDir,
+    pub signer: Arc<KMSSigner>,
+}
+
+impl TestKMSSigner {
+    /// Creates a test signing process for KMS
+    pub fn new(local_kms_exe: &str) -> Result<TestKMSSigner, AppleCodesignError> {
+        let tmpdir = TempDir::new()?;
+        let mut parts = None;
+        'trying: for attempt in 1..=5 {
+            if attempt == 5 {
+                return Err(AppleCodesignError::AWSKMSError(
+                    "Failed to start up local-kms".into(),
+                ));
+            }
+            let try_port = rand::thread_rng().gen_range(2000u16..65535);
+
+            let mut proc = Command::new(local_kms_exe)
+                .env("KMS_DATA_PATH", tmpdir.path())
+                .env("KMS_SEED_PATH", "/dev/null")
+                // TODO: this needs to be set somehow safely, I guess we can read
+                // the stderr and watch for the log line for starting
+                // successfully??
+                .env("PORT", try_port.to_string())
+                .stderr(Stdio::piped())
+                .spawn()?;
+            let pipe = proc.stderr.take().unwrap();
+            let mut buf_reader = BufReader::new(pipe);
+            let mut buf = String::new();
+
+            while let Ok(read) = buf_reader.read_line(&mut buf) {
+                println!("{}", buf);
+                if read == 0 {
+                    // EOF before we got a startup message, that seems bad
+                    continue 'trying;
+                }
+                if buf.contains("started on") {
+                    // we got one! we unfortunately can't drop the stderr for
+                    // the daemon as it will cause it to terminate, so we have
+                    // to have a thread reading it and throwing it away.
+                    let logger_thread = std::thread::spawn(move || {
+                        let mut buf = vec![0; 100];
+                        while let Ok(_) = buf_reader.read(&mut buf) {}
+                    });
+                    parts = Some((proc, try_port, logger_thread));
+                    break 'trying;
+                }
+                buf.clear();
+            }
+        }
+        let (process, port, logger_thread) = parts.unwrap();
+
+        let signer = KMSSigner::new_local(port)?;
+
+        Ok(TestKMSSigner {
+            _stderr_logger: logger_thread,
+            tmpdir,
+            process,
+            signer,
+        })
+    }
+}
+
+impl Drop for TestKMSSigner {
+    fn drop(&mut self) {
+        let _ = self.process.kill();
+    }
+}
+
 impl KMSSigner {
+    /// Creates a new KMSSigner for production use.
     pub fn new() -> Result<Arc<KMSSigner>, AppleCodesignError> {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
 
         let config = runtime.block_on(aws_config::load_defaults(BehaviorVersion::v2026_01_12()));
+        let client = aws_sdk_kms::Client::new(&config);
+        Ok(Arc::new(KMSSigner { runtime, client }))
+    }
+
+    pub fn new_local(port: u16) -> Result<Arc<KMSSigner>, AppleCodesignError> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let config = runtime.block_on(
+            aws_config::defaults(BehaviorVersion::v2026_01_12())
+                .endpoint_url(format!("http://localhost:{port}"))
+                .test_credentials()
+                .region("eu-west-2")
+                .load(),
+        );
         let client = aws_sdk_kms::Client::new(&config);
         Ok(Arc::new(KMSSigner { runtime, client }))
     }
@@ -85,6 +193,26 @@ impl AWSKMSKey {
             public_key_info: actual_pubkey,
             key_id,
         })
+    }
+
+    /// Creates a new signing key on KMS.
+    ///
+    /// This function is intended only for use in tests.
+    pub async fn create_key(
+        signer: Arc<KMSSigner>,
+        alg: KeyAlgorithm,
+    ) -> Result<(String, Self), AppleCodesignError> {
+        let new_key = signer
+            .client
+            .create_key()
+            .key_spec(key_algorithm_to_aws(alg))
+            .key_usage(aws_sdk_kms::types::KeyUsageType::SignVerify)
+            .send()
+            .await
+            .expect("creating kms key, testing only");
+
+        let key_id = &new_key.key_metadata.expect("key metadata missing").key_id;
+        Ok((key_id.clone(), Self::new(signer, key_id.clone()).await?))
     }
 
     pub fn public_key_info(&self) -> &SubjectPublicKeyInfo {
@@ -224,5 +352,27 @@ impl PrivateKey for AWSKMSKey {
 
     fn finish(&self) -> Result<(), AppleCodesignError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> TestKMSSigner {
+        TestKMSSigner::new("/Users/jade/go/bin/local-kms").expect("making test kms signer")
+    }
+
+    #[test]
+    fn test_sign_foo() {
+        let test = fixture();
+        let key = test
+            .signer
+            .runtime
+            .block_on(AWSKMSKey::create_key(
+                test.signer.clone(),
+                KeyAlgorithm::Rsa,
+            ))
+            .unwrap();
     }
 }

--- a/apple-codesign/src/cryptography.rs
+++ b/apple-codesign/src/cryptography.rs
@@ -300,6 +300,7 @@ impl<'a> TryFrom<PrivateKeyInfo<'a>> for InMemoryPrivateKey {
                 let curve_oid = value.algorithm.parameters_oid()?;
 
                 match curve_oid.as_bytes() {
+                    // FIXME(jade): support more curves
                     x if x == OID_EC_P256.as_bytes() => {
                         let secret_key = ECSecretKey::<NistP256>::try_from(value)?;
 

--- a/apple-codesign/src/error.rs
+++ b/apple-codesign/src/error.rs
@@ -368,6 +368,34 @@ pub enum AppleCodesignError {
     #[error("zip structs error: {0}")]
     ZipStructs(#[from] zip_structs::zip_error::ZipReadError),
 
+    #[error("AWS KMS error: {0}")]
+    AWSKMSError(String),
+
+    #[cfg(feature = "aws-kms")]
+    #[error("AWS KMS sign error: {0}")]
+    AWSKMSSignError(
+        Box<
+            aws_smithy_types::error::display::DisplayErrorContext<
+                aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::sign::SignError>,
+            >,
+        >,
+    ),
+
+    #[cfg(feature = "aws-kms")]
+    #[error("AWS KMS get public key error: {0}")]
+    AWSKMSGetPublicKeyError(
+        Box<
+            aws_smithy_types::error::display::DisplayErrorContext<
+                aws_sdk_kms::error::SdkError<
+                    aws_sdk_kms::operation::get_public_key::GetPublicKeyError,
+                >,
+            >,
+        >,
+    ),
+
+    #[error("Selected private key is not usable: {0}")]
+    KeyNotUsable(String),
+
     #[error("PKCS11 error: {0}")]
     Pkcs11Error(String),
 

--- a/apple-codesign/src/lib.rs
+++ b/apple-codesign/src/lib.rs
@@ -168,5 +168,8 @@ pub mod windows;
 #[cfg(feature = "yubikey")]
 pub mod yubikey;
 
+#[cfg(feature = "aws-kms")]
+pub mod aws_kms;
+
 #[cfg(feature = "pkcs11")]
 pub mod pkcs11;

--- a/apple-codesign/src/signing_settings.rs
+++ b/apple-codesign/src/signing_settings.rs
@@ -279,7 +279,7 @@ impl ScopedSetting {
 /// Represents code signing settings.
 ///
 /// This type holds settings related to a single logical signing operation.
-/// Some settings (such as the signing key-pair are global). Other settings
+/// Some settings (such as the signing key-pair) are global. Other settings
 /// (such as the entitlements or designated requirement) can be applied on a
 /// more granular, scoped basis. The scoping of these lower-level settings is
 /// controlled via [SettingsScope]. If a setting is specified with a scope, it

--- a/apple-codesign/src/windows.rs
+++ b/apple-codesign/src/windows.rs
@@ -386,6 +386,9 @@ impl Signer<Signature> for StoreCertificate {
 
 impl Sign for StoreCertificate {
     fn sign(&self, message: &[u8]) -> Result<(Vec<u8>, SignatureAlgorithm), X509CertificateError> {
+        // FIXME(jade): this is likely buggy and wrong: this is the signature
+        // algorithm of this *certificate*, which is not the algorithm used by
+        // the signature function. However, this function isn't used.
         let algorithm = self.signature_algorithm()?;
 
         Ok((self.try_sign(message)?.into(), algorithm))


### PR DESCRIPTION
I found a bug in the docs in cryptography-rs, which I think actually is a bug in basically every extant provider: https://github.com/indygreg/cryptography-rs/pull/68 We also don't use the sign() function afaik, so I suspect it was never noticed.

This appears to produce correct looking results in Apparency. I've tested it with a self signed cert from rcodesign which I imported the private key of into KMS.

The motivation for this feature rather than PKCS11 is that 1. PKCS11 is a pain in the ass (especially with AWS KMS where there is an unofficial PKCS11 but it's not packaged in nixpkgs and it's just . a lot of complexity) and 2. AWS CloudHSM is really *really* expensive ($1/hour!!), so KMS makes more sense to use in practice ($1/month/key to Not Have Stealable Keys is awesome actually).

TODOs:
- Figure out testing. Integration testing this is probably going to suck, but it is possible. Try: https://github.com/nsmithuk/local-kms

  I don't think there is that much *code* to unit test here and we would probably have to introduce a mocking layer over the KMS API (which seems to likely defeat the purpose).
- Cleanup pass on the code.
  - DRY up some common functionality between PKCS11 and AWS KMS. I assume this is going to be reused by most implementations of cloud signing.
- Remove default-on aws-kms feature.
- Docs