### PR TITLE
fix: apply 0o775 permissions

### DIFF
--- a/apple-codesign/src/bundle_signing.rs
+++ b/apple-codesign/src/bundle_signing.rs
@@ -469,6 +469,14 @@ impl<'a, 'key> BundleSigningContext<'a, 'key> {
     ) -> Result<(PathBuf, SignedMachOInfo), AppleCodesignError> {
         warn!("signing Mach-O file {}", bundle_rel_path.display());
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(source_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(source_path, perms)?;
+        }
+
         let macho_data = std::fs::read(source_path)?;
         let signer = MachOSigner::new(&macho_data)?;
 
@@ -722,6 +730,14 @@ impl SingleBundleSigner {
         // Seal the main executable.
         if let Some(exe) = main_exe {
             warn!("signing main executable {}", exe.relative_path().display());
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(exe.absolute_path())?.permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(exe.absolute_path(), perms)?;
+            }
 
             let macho_data = std::fs::read(exe.absolute_path())?;
             let signer = MachOSigner::new(&macho_data)?;

--- a/apple-codesign/src/signing.rs
+++ b/apple-codesign/src/signing.rs
@@ -66,6 +66,15 @@ impl<'key> UnifiedSigner<'key> {
         let output_path = output_path.as_ref();
 
         warn!("signing {} as a Mach-O binary", input_path.display());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(input_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(input_path, perms)?;
+        }
+
         let macho_data = std::fs::read(input_path)?;
 
         let mut settings = self.settings.clone();


### PR DESCRIPTION
On iOS, binaries without `0o755` permissions are able to be executed just fine without this change.

On macOS, this fix is needed because often 3rd party developers don't properly set permissions when distributing their iOS apps, making their app unable to properly run on macOS (saying that the app is damaged, or cannot be opened).

Context: I use this codesigning package for installing iOS apps for [Impactor](https://github.com/khcrysalis/Impactor), this also supports installing iOS apps on a macOS arm64 machine. This is where these problems arise.

<img width="1150" height="182" alt="image" src="https://github.com/user-attachments/assets/7c1c08d5-e9db-40d4-926c-4205ff088fdf" />
