### PR TITLE
apple-codesign: don't use aws_config::defaults for S3 client during notarization

### DIFF
--- a/apple-codesign/src/notarization.rs
+++ b/apple-codesign/src/notarization.rs
@@ -299,23 +299,23 @@ impl Notarizer {
 
         // upload using s3 api
         warn!("resolving AWS S3 configuration from Apple-provided credentials");
-        let config = rt.block_on(
-            aws_config::defaults(aws_config::BehaviorVersion::latest())
-                .credentials_provider(Credentials::new(
-                    submission.data.attributes.aws_access_key_id.clone(),
-                    submission.data.attributes.aws_secret_access_key.clone(),
-                    Some(submission.data.attributes.aws_session_token.clone()),
-                    None,
-                    "apple-codesign",
-                ))
-                // The region is not given anywhere in the Apple documentation. From
-                // manually testing all available regions, it appears to be
-                // us-west-2.
-                .region(Region::new("us-west-2"))
-                .load(),
-        );
 
-        let s3_client = aws_sdk_s3::Client::new(&config);
+        let config = aws_sdk_s3::config::Builder::new()
+            .credentials_provider(Credentials::new(
+                submission.data.attributes.aws_access_key_id.clone(),
+                submission.data.attributes.aws_secret_access_key.clone(),
+                Some(submission.data.attributes.aws_session_token.clone()),
+                None,
+                "apple-codesign",
+            ))
+            // The region is not given anywhere in the Apple documentation. From
+            // manually testing all available regions, it appears to be
+            // us-west-2.
+            .region(Region::new("us-west-2"))
+            .behavior_version(aws_sdk_s3::config::BehaviorVersion::latest())
+            .build();
+
+        let s3_client = aws_sdk_s3::Client::from_conf(config);
 
         warn!(
             "uploading asset to s3://{}/{}",


### PR DESCRIPTION
This changes the S3 client construction to not use `aws_config::defaults`. It will still load the latest behaviour version though.

`aws_config::defaults` will load configuration from the environment and `~/.aws` (and probably other places?). We explicitly don't want to load them and any credential providers/service overrides they provide because Apple's workflow explicitly specifies everything with their STS.

## Testing

Tested with an without config overrides in `~/.aws` and ENV variables.

Simplest breaking test is to add this to `~/.aws/config`:

```
[default]
endpoint_url = http://localhost
```

Prior to this change, notarization will fail by trying to upload the payload to `localhost` when `aws_config::defaults` loads that endpoint_url override.

After this change, notarization will correctly ignore the `~/.aws/config` and overrides in the `[default]` section and succeed.