### PR TITLE
Don't try to seal/sign fat static archives

### DIFF
--- a/apple-codesign/CHANGELOG.md
+++ b/apple-codesign/CHANGELOG.md
@@ -13,6 +13,9 @@ Released on ReleaseDate.
 * Interpret empty signature data in Mach-O load command as a missing signature.
   (#183)
 * Handle DER plists encoded as a SET. (#182)
+* `MachOSigner::new()` now returns an error instead of panicking when the
+  input parses as Mach-O but contains no architectures (e.g. a universal
+  static archive whose members are `ar` archives).
 * Notarization network polling now handles some transient network errors. (#174)
 * MSRV 1.81 -> 1.92.
 * `aws-smithy-http` 0.60 -> 0.62.

--- a/apple-codesign/CHANGELOG.md
+++ b/apple-codesign/CHANGELOG.md
@@ -16,6 +16,10 @@ Released on ReleaseDate.
 * `MachOSigner::new()` now returns an error instead of panicking when the
   input parses as Mach-O but contains no architectures (e.g. a universal
   static archive whose members are `ar` archives).
+* Bundle signing now seals non-signable Mach-O like files (universal static
+  archives, dSYM DWARF companions, and other Mach-O files that cannot hold a
+  code signature) as regular resources instead of attempting to sign them,
+  matching the behavior of Apple's `codesign`.
 * Notarization network polling now handles some transient network errors. (#174)
 * MSRV 1.81 -> 1.92.
 * `aws-smithy-http` 0.60 -> 0.62.

--- a/apple-codesign/src/code_resources.rs
+++ b/apple-codesign/src/code_resources.rs
@@ -1368,7 +1368,7 @@ impl CodeResourcesBuilder {
             // to behave like Apple's `codesign` and that tool only signs the bundle's
             // "main" Mach-O binary, not other binaries.
             let sign_macho = need_install
-                && crate::reader::path_is_macho(full_path)?
+                && crate::reader::path_is_signable_macho(full_path)?
                 && !context
                     .settings
                     .path_exclusion_pattern_matches(root_rel_path)

--- a/apple-codesign/src/macho_signing.rs
+++ b/apple-codesign/src/macho_signing.rs
@@ -323,6 +323,19 @@ impl<'data> MachOSigner<'data> {
     pub fn new(macho_data: &'data [u8]) -> Result<Self, AppleCodesignError> {
         let machos = MachFile::parse(macho_data)?.into_iter().collect::<Vec<_>>();
 
+        // A fat/universal container with no Mach-O architectures (e.g. a
+        // universal *static archive* such as libclang_rt.osx.a, whose members
+        // are `ar` archives rather than Mach-O binaries) parses fine but
+        // yields no signable binaries. Reject it here so signing code can
+        // assume at least one binary is present.
+        if machos.is_empty() {
+            return Err(AppleCodesignError::InvalidBinary(
+                "no Mach-O architectures found to sign; the input is not a signable Mach-O \
+                 binary (e.g. a fat/universal static archive)"
+                    .to_string(),
+            ));
+        }
+
         Ok(Self { machos })
     }
 

--- a/apple-codesign/src/reader.rs
+++ b/apple-codesign/src/reader.rs
@@ -110,6 +110,38 @@ pub fn path_is_macho(path: impl AsRef<Path>) -> Result<bool, AppleCodesignError>
     Ok(MachOType::from_path(path)?.is_some())
 }
 
+/// Whether the file at `path` is a Mach-O that can actually be code-signed.
+///
+/// A file can carry Mach-O or fat/universal magic yet not be signable:
+/// a static archive like `libclang_rt.osx.a` is an `ar` archive with a fat
+/// magic but zero Mach-O slices, and files like dSYM DWARF companions parse
+/// as Mach-O but cannot hold a code signature. Apple's `codesign` seals such
+/// files as ordinary bundle resources. Use this (not [`path_is_macho`]) to
+/// decide whether to *sign* a file within a bundle.
+pub fn path_is_signable_macho(path: impl AsRef<Path>) -> Result<bool, AppleCodesignError> {
+    let path = path.as_ref();
+    if !path_is_macho(path)? {
+        return Ok(false);
+    }
+    let data = std::fs::read(path)?;
+    let machos = match MachFile::parse(&data) {
+        Ok(m) => m,
+        Err(_) => return Ok(false),
+    };
+
+    // Signable means there is at least one Mach-O slice and every slice is
+    // capable of holding a code signature.
+    let mut signable = false;
+    for macho in machos {
+        if macho.check_signing_capability().is_err() {
+            return Ok(false);
+        }
+        signable = true;
+    }
+
+    Ok(signable)
+}
+
 /// Describes the type of entity at a path.
 ///
 /// This represents a best guess.


### PR DESCRIPTION
This fixes two related issues found while attempting to use rcodesign to sign binaries for Julia (https://github.com/JuliaLang/julia). Since Julia is a compiler, it ships runtime libraries like libclang_rt.osx.a, which are fat Mach-O archives, but are not codesignable.

AI Disclosure: These commits were written by Claude, but tested separately. That said, I am personally not particularly familiar with this codebase either, so possibly there is a better way.