### PR TITLE
codesign/notarize: Support AWS KMS as a backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,8 @@ name = "app-store-connect"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-sdk-kms",
  "base64",
  "clap",
  "dirs",
@@ -151,7 +153,9 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
+ "tokio",
  "x509-certificate",
 ]
 
@@ -189,6 +193,7 @@ dependencies = [
  "apple-flat-package",
  "apple-xar",
  "aws-config",
+ "aws-sdk-kms",
  "aws-sdk-s3",
  "aws-smithy-http 0.62.6",
  "aws-smithy-types",
@@ -400,6 +405,7 @@ checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-signin",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
@@ -410,15 +416,20 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "base64-simd",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.0",
+ "p256 0.13.2",
+ "rand 0.8.6",
  "sha1 0.10.6",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -485,6 +496,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-kms"
+version = "1.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41ae6a33da941457e89075ef8ca5b4870c8009fe4dceeba82fce2f30f313ac6"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +552,30 @@ dependencies = [
  "sha2 0.10.9",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "aws-sdk-signin"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83ed6776794d4f6e28f8055a1ab2b64c2bac84fd2b6ecf967b979196c526c44"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "env_logger",
  "jsonwebtoken",
  "log",
+ "p256 0.13.2",
  "pem",
  "rand 0.8.6",
  "reqwest",

--- a/app-store-connect/CHANGELOG.md
+++ b/app-store-connect/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Released on ReleaseDate.
 
+* Added `Es256Signer` trait and `ConnectTokenEncoder::from_es256_signer()`,
+  allowing API tokens to be signed by an external signer (e.g. an HSM or a
+  cloud KMS holding the App Store Connect API private key) instead of an
+  in-memory private key.
 * MSRV 1.81 -> 1.92.
 * `dirs` 5 -> 6.
 * `x509-certificate` 0.24 -> 0.25.

--- a/app-store-connect/CHANGELOG.md
+++ b/app-store-connect/CHANGELOG.md
@@ -10,6 +10,10 @@ Released on ReleaseDate.
   allowing API tokens to be signed by an external signer (e.g. an HSM or a
   cloud KMS holding the App Store Connect API private key) instead of an
   in-memory private key.
+* Added a new (default off) `aws-kms` crate feature providing
+  `AwsKmsEs256Signer`, an `Es256Signer` that signs via AWS KMS.
+  `UnifiedApiKey` can now reference an AWS KMS key (`aws_kms_key` /
+  `aws_kms_region` fields) instead of embedding private key material.
 * MSRV 1.81 -> 1.92.
 * `dirs` 5 -> 6.
 * `x509-certificate` 0.24 -> 0.25.

--- a/app-store-connect/Cargo.toml
+++ b/app-store-connect/Cargo.toml
@@ -26,3 +26,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
 x509-certificate = "0.25.0"
+
+[dev-dependencies]
+p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "std"] }

--- a/app-store-connect/Cargo.toml
+++ b/app-store-connect/Cargo.toml
@@ -10,8 +10,13 @@ homepage = "https://github.com/indygreg/apple-platform-rs"
 repository = "https://github.com/indygreg/apple-platform-rs.git"
 readme = "README.md"
 
+[features]
+aws-kms = ["aws-config", "aws-config/credentials-login", "aws-sdk-kms", "p256", "sha2", "tokio"]
+
 [dependencies]
 anyhow = "1.0.102"
+aws-config = { version = "1.8.13", optional = true }
+aws-sdk-kms = { version = "1.86.0", optional = true }
 base64 = "0.22.1"
 clap = { version = "4.6.1", features = ["derive"] }
 dirs = "6.0.0"
@@ -19,12 +24,15 @@ env_logger = "0.11.10"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 log = "0.4.29"
 pem = "3.0.6"
+p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "std"], optional = true }
 rand = "0.8.6"
 reqwest = { version = "0.12.28", default-features = false, features = ["blocking", "http2", "json", "rustls-tls-native-roots"] }
 rsa = "0.9.10"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+sha2 = { version = "0.10.9", optional = true }
 thiserror = "2.0.18"
+tokio = { version = "1.52.1", features = ["rt"], optional = true }
 x509-certificate = "0.25.0"
 
 [dev-dependencies]

--- a/app-store-connect/src/api_key.rs
+++ b/app-store-connect/src/api_key.rs
@@ -44,7 +44,22 @@ pub struct UnifiedApiKey {
     key_id: String,
 
     /// Base64 encoded DER of ECDSA private key material.
-    private_key: String,
+    ///
+    /// Mutually exclusive with `aws_kms_key`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    private_key: Option<String>,
+
+    /// AWS KMS key ID, key ARN, or alias ARN holding the private key.
+    ///
+    /// When set, signing operations are performed remotely via AWS KMS and
+    /// this file contains no secret material. Mutually exclusive with
+    /// `private_key`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    aws_kms_key: Option<String>,
+
+    /// AWS region of the KMS key (optional; overrides environment / profile).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    aws_kms_region: Option<String>,
 }
 
 impl UnifiedApiKey {
@@ -70,8 +85,30 @@ impl UnifiedApiKey {
         Ok(Self {
             issuer_id: issuer_id.to_string(),
             key_id: key_id.to_string(),
-            private_key,
+            private_key: Some(private_key),
+            aws_kms_key: None,
+            aws_kms_region: None,
         })
+    }
+
+    /// Construct an instance referencing a private key held in AWS KMS.
+    ///
+    /// The resulting instance (and its JSON serialization) contains no
+    /// secret material: signing requires AWS credentials authorized to
+    /// use the referenced KMS key.
+    pub fn from_aws_kms_key(
+        issuer_id: impl ToString,
+        key_id: impl ToString,
+        aws_kms_key: impl ToString,
+        aws_kms_region: Option<String>,
+    ) -> Self {
+        Self {
+            issuer_id: issuer_id.to_string(),
+            key_id: key_id.to_string(),
+            private_key: None,
+            aws_kms_key: Some(aws_kms_key.to_string()),
+            aws_kms_region,
+        }
     }
 
     /// Construct an instance from serialized JSON.
@@ -122,11 +159,39 @@ impl TryFrom<UnifiedApiKey> for ConnectTokenEncoder {
     type Error = anyhow::Error;
 
     fn try_from(value: UnifiedApiKey) -> Result<Self> {
-        let der = STANDARD_ENGINE
-            .decode(value.private_key)
-            .context("invalid unified api key")?;
+        if let Some(private_key) = value.private_key {
+            let der = STANDARD_ENGINE
+                .decode(private_key)
+                .context("invalid unified api key")?;
 
-        Self::from_ecdsa_der(value.key_id, value.issuer_id, &der)
+            return Self::from_ecdsa_der(value.key_id, value.issuer_id, &der);
+        }
+
+        if let Some(kms_key) = value.aws_kms_key {
+            #[cfg(feature = "aws-kms")]
+            {
+                let signer =
+                    crate::aws_kms::AwsKmsEs256Signer::new(kms_key, value.aws_kms_region)?;
+
+                return Ok(Self::from_es256_signer(
+                    value.key_id,
+                    value.issuer_id,
+                    std::sync::Arc::new(signer),
+                ));
+            }
+
+            #[cfg(not(feature = "aws-kms"))]
+            {
+                return Err(anyhow::anyhow!(
+                    "unified api key references AWS KMS key {kms_key} but AWS KMS support \
+                     is not compiled in (enable the `aws-kms` Cargo feature)"
+                ));
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "unified api key defines neither `private_key` nor `aws_kms_key`"
+        ))
     }
 }
 

--- a/app-store-connect/src/api_token.rs
+++ b/app-store-connect/src/api_token.rs
@@ -8,11 +8,27 @@
 
 use {
     crate::Result,
+    base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine},
     jsonwebtoken::{Algorithm, EncodingKey, Header},
     serde::{Deserialize, Serialize},
-    std::{path::Path, time::SystemTime},
+    std::{path::Path, sync::Arc, time::SystemTime},
     thiserror::Error,
 };
+
+/// A signer capable of producing ES256 (ECDSA P-256 + SHA-256) JWT signatures.
+///
+/// Implementations sign the JWS *signing input* (the
+/// `base64url(header) + "." + base64url(claims)` byte string) and return the
+/// raw 64 byte `r || s` signature (NOT ASN.1 DER encoded), as required by
+/// RFC 7518 for the `ES256` algorithm.
+///
+/// This abstraction allows JWT signing keys to live in remote key stores
+/// (HSMs, cloud KMS services, etc) without exposing private key material.
+pub trait Es256Signer: Send + Sync {
+    /// Compute the ES256 signature of `message`, returning the raw 64 byte
+    /// `r || s` encoding.
+    fn sign_es256(&self, message: &[u8]) -> Result<Vec<u8>>;
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct ConnectTokenRequest {
@@ -42,16 +58,25 @@ pub type AppStoreConnectToken = String;
 /// All these are issued by Apple. You can log in to App Store Connect and see/manage your keys
 /// at https://appstoreconnect.apple.com/access/api.
 #[derive(Clone)]
+enum TokenSigningKey {
+    /// A private key held in memory, signed via the jsonwebtoken crate.
+    EncodingKey(EncodingKey),
+    /// An external signer (e.g. a cloud KMS or HSM).
+    Custom(Arc<dyn Es256Signer>),
+}
+
+#[derive(Clone)]
 pub struct ConnectTokenEncoder {
     key_id: String,
     issuer_id: String,
-    encoding_key: EncodingKey,
+    signing_key: TokenSigningKey,
 }
 
 impl ConnectTokenEncoder {
     /// Construct an instance from an [EncodingKey] instance.
     ///
-    /// This is the lowest level API and ultimately what all constructors use.
+    /// This is the lowest level API for in-memory keys and what all
+    /// in-memory key constructors use.
     pub fn from_jwt_encoding_key(
         key_id: String,
         issuer_id: String,
@@ -60,7 +85,23 @@ impl ConnectTokenEncoder {
         Self {
             key_id,
             issuer_id,
-            encoding_key,
+            signing_key: TokenSigningKey::EncodingKey(encoding_key),
+        }
+    }
+
+    /// Construct an instance from an external [Es256Signer].
+    ///
+    /// Use this when the private key lives in a remote key store (HSM,
+    /// cloud KMS, ...) and cannot be loaded into memory.
+    pub fn from_es256_signer(
+        key_id: String,
+        issuer_id: String,
+        signer: Arc<dyn Es256Signer>,
+    ) -> Self {
+        Self {
+            key_id,
+            issuer_id,
+            signing_key: TokenSigningKey::Custom(signer),
         }
     }
 
@@ -141,7 +182,24 @@ impl ConnectTokenEncoder {
             aud: "appstoreconnect-v1".to_string(),
         };
 
-        let token = jsonwebtoken::encode(&header, &claims, &self.encoding_key)?;
+        let token = match &self.signing_key {
+            TokenSigningKey::EncodingKey(encoding_key) => {
+                jsonwebtoken::encode(&header, &claims, encoding_key)?
+            }
+            TokenSigningKey::Custom(signer) => {
+                // Assemble the JWS by hand, since jsonwebtoken's encode()
+                // requires the private key in memory.
+                let signing_input = format!(
+                    "{}.{}",
+                    URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header)?),
+                    URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims)?)
+                );
+
+                let signature = signer.sign_es256(signing_input.as_bytes())?;
+
+                format!("{}.{}", signing_input, URL_SAFE_NO_PAD.encode(signature))
+            }
+        };
 
         Ok(token)
     }
@@ -150,3 +208,49 @@ impl ConnectTokenEncoder {
 #[derive(Clone, Copy, Debug, Error)]
 #[error("no app store connect api key found")]
 pub struct MissingApiKey;
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        p256::ecdsa::{signature::Signer as _, Signature, SigningKey},
+    };
+
+    /// An [Es256Signer] backed by an in-memory P-256 key.
+    struct LocalEs256Signer {
+        key: SigningKey,
+    }
+
+    impl Es256Signer for LocalEs256Signer {
+        fn sign_es256(&self, message: &[u8]) -> Result<Vec<u8>> {
+            let signature: Signature = self.key.sign(message);
+            Ok(signature.to_bytes().to_vec())
+        }
+    }
+
+    #[test]
+    fn custom_signer_token_verifies() -> Result<()> {
+        let key = SigningKey::random(&mut rand::thread_rng());
+        let public_key = key.verifying_key().to_sec1_bytes().to_vec();
+
+        let encoder = ConnectTokenEncoder::from_es256_signer(
+            "DEADBEEF42".into(),
+            "issuer-uuid".into(),
+            Arc::new(LocalEs256Signer { key }),
+        );
+
+        let token = encoder.new_token(300)?;
+
+        let decoding_key = jsonwebtoken::DecodingKey::from_ec_der(&public_key);
+        let mut validation = jsonwebtoken::Validation::new(Algorithm::ES256);
+        validation.set_audience(&["appstoreconnect-v1"]);
+
+        let decoded =
+            jsonwebtoken::decode::<ConnectTokenRequest>(&token, &decoding_key, &validation)?;
+
+        assert_eq!(decoded.claims.iss, "issuer-uuid");
+        assert_eq!(decoded.header.kid.as_deref(), Some("DEADBEEF42"));
+
+        Ok(())
+    }
+}

--- a/app-store-connect/src/aws_kms.rs
+++ b/app-store-connect/src/aws_kms.rs
@@ -1,0 +1,96 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! ES256 JWT signing backed by AWS KMS.
+//!
+//! This allows the App Store Connect API private key (an ECDSA P-256 key)
+//! to live in AWS KMS so that the key material is never exposed to the
+//! machine performing notarization.
+//!
+//! AWS credentials are resolved through the standard SDK default provider
+//! chain, which includes web identity federation (OIDC) via the
+//! `AWS_WEB_IDENTITY_TOKEN_FILE` / `AWS_ROLE_ARN` environment variables.
+
+use {
+    crate::{api_token::Es256Signer, Result},
+    anyhow::anyhow,
+    aws_sdk_kms::{
+        error::DisplayErrorContext,
+        primitives::Blob,
+        types::{MessageType, SigningAlgorithmSpec},
+    },
+    sha2::{Digest, Sha256},
+};
+
+/// An [Es256Signer] that signs with an ECDSA P-256 key held in AWS KMS.
+pub struct AwsKmsEs256Signer {
+    key_id: String,
+    client: aws_sdk_kms::Client,
+    rt: tokio::runtime::Runtime,
+}
+
+impl AwsKmsEs256Signer {
+    /// Construct an instance from a KMS key ID, key ARN, or alias.
+    ///
+    /// `region`, if given, overrides the region from the environment / profile.
+    pub fn new(key_id: String, region: Option<String>) -> Result<Self> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+        if let Some(region) = region {
+            loader = loader.region(aws_sdk_kms::config::Region::new(region));
+        }
+
+        let config = rt.block_on(loader.load());
+        let client = aws_sdk_kms::Client::new(&config);
+
+        Ok(Self { key_id, client, rt })
+    }
+
+    /// The KMS key ID, key ARN, or alias this signer uses.
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+}
+
+impl Es256Signer for AwsKmsEs256Signer {
+    fn sign_es256(&self, message: &[u8]) -> Result<Vec<u8>> {
+        let digest = Sha256::digest(message).to_vec();
+
+        let response = self
+            .rt
+            .block_on(
+                self.client
+                    .sign()
+                    .key_id(&self.key_id)
+                    .message(Blob::new(digest))
+                    .message_type(MessageType::Digest)
+                    .signing_algorithm(SigningAlgorithmSpec::EcdsaSha256)
+                    .send(),
+            )
+            .map_err(|e| {
+                anyhow!(
+                    "AWS KMS Sign failed for key {}: {}",
+                    self.key_id,
+                    DisplayErrorContext(&e)
+                )
+            })?;
+
+        let der_signature = response
+            .signature()
+            .ok_or_else(|| anyhow!("AWS KMS Sign response missing signature"))?
+            .as_ref();
+
+        // KMS returns ECDSA signatures in ASN.1 DER form. JWS ES256 requires
+        // the raw 64 byte r || s encoding (RFC 7518 section 3.4).
+        let signature = p256::ecdsa::Signature::from_der(der_signature)
+            .map_err(|e| anyhow!("failed to parse KMS ECDSA signature: {e}"))?;
+
+        Ok(signature.to_bytes().to_vec())
+    }
+}

--- a/app-store-connect/src/lib.rs
+++ b/app-store-connect/src/lib.rs
@@ -6,6 +6,8 @@
 
 mod api_key;
 mod api_token;
+#[cfg(feature = "aws-kms")]
+pub mod aws_kms;
 pub mod bundle_api;
 pub mod certs_api;
 pub mod cli;

--- a/app-store-connect/src/lib.rs
+++ b/app-store-connect/src/lib.rs
@@ -21,7 +21,9 @@ use {
 };
 
 pub use crate::api_key::{InvalidPemPrivateKey, UnifiedApiKey};
-pub use crate::api_token::{AppStoreConnectToken, ConnectTokenEncoder, MissingApiKey};
+pub use crate::api_token::{
+    AppStoreConnectToken, ConnectTokenEncoder, Es256Signer, MissingApiKey,
+};
 
 pub type Result<T> = anyhow::Result<T>;
 

--- a/apple-codesign/CHANGELOG.md
+++ b/apple-codesign/CHANGELOG.md
@@ -8,6 +8,13 @@ Released on ReleaseDate.
 
 * PKCS#11 support. (Support signing with Google Cloud HSM, SoftHSM, other
   PKCS#11 based signing providers.) (#198)
+* AWS KMS support via a new (default off) `aws-kms` crate feature. Signing
+  can use an asymmetric key held in AWS KMS (the private key never leaves
+  KMS) via new `--aws-kms-key`, `--aws-kms-certificate-file`, and
+  `--aws-kms-region` arguments or an `[sign.aws_kms]` config file section.
+  `encode-app-store-connect-api-key` gained `--aws-kms-key` /
+  `--aws-kms-region` arguments so notarization JWTs can also be minted by a
+  KMS held key.
 * Mach-O file sniffing has been refined to prevent false positives on
   Java `.class` files. (#175)
 * Interpret empty signature data in Mach-O load command as a missing signature.

--- a/apple-codesign/Cargo.toml
+++ b/apple-codesign/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.102"
 aws-config = { version = "1.8.13", optional = true }
+aws-sdk-kms = { version = "1.86.0", optional = true }
 aws-sdk-s3 = { version = "1.122.0", optional = true }
 aws-smithy-http = { version = "0.62.6", optional = true }
 aws-smithy-types = { version = "1.4.3", optional = true }
@@ -131,3 +132,4 @@ notarize = [
 ]
 smartcard = ["yubikey"]
 pkcs11 = ["cryptoki"]
+aws-kms = ["aws-config", "aws-config/credentials-login", "aws-sdk-kms", "app-store-connect?/aws-kms"]

--- a/apple-codesign/docs/apple_codesign.rst
+++ b/apple-codesign/docs/apple_codesign.rst
@@ -26,6 +26,7 @@ Other features include:
 * Built-in support for using :ref:`smart cards <apple_codesign_smartcard>` (e.g.
   YubiKeys) for signing and key/certificate management.
 * PKCS#11 support (sign with HSMs, etc). See :ref:`apple_codesign_pkcs11` for more.
+* AWS KMS support (sign with keys held in AWS KMS). See :ref:`apple_codesign_aws_kms` for more.
 * A *remote signing* mode that enables you to delegate just the low-level
   cryptographic signature generation to a remote machine. This allows you to
   do things like have a CI job initiate signing but use a YubiKey on a remote
@@ -59,6 +60,7 @@ to be used as a standalone project.
    apple_codesign_rcodesign
    apple_codesign_certificate_management
    apple_codesign_pkcs11
+   apple_codesign_aws_kms
    apple_codesign_smartcard
    apple_codesign_github_actions
    apple_codesign_concepts

--- a/apple-codesign/docs/apple_codesign_aws_kms.rst
+++ b/apple-codesign/docs/apple_codesign_aws_kms.rst
@@ -1,0 +1,77 @@
+.. _apple_codesign_aws_kms:
+
+=====================
+Signing with AWS KMS
+=====================
+
+``rcodesign`` supports signing with asymmetric keys held in
+`AWS KMS <https://docs.aws.amazon.com/kms/>`_. The private key never leaves
+KMS: each signing operation calls the KMS ``Sign`` API.
+
+AWS KMS support requires the ``aws-kms`` Cargo feature to be enabled:
+
+.. code-block:: bash
+
+    cargo build --features aws-kms
+
+Credentials
+===========
+
+AWS credentials are resolved through the standard AWS SDK default provider
+chain: environment variables, shared config/credentials files, IMDS, and web
+identity federation (OIDC) via ``AWS_WEB_IDENTITY_TOKEN_FILE`` /
+``AWS_ROLE_ARN``. The latter is particularly useful in CI environments
+(GitHub Actions, Buildkite, GitLab CI) which can mint OIDC identity tokens,
+allowing code signing without any long-lived secrets.
+
+The principal needs ``kms:GetPublicKey`` and ``kms:Sign`` permissions on
+the signing key.
+
+Code signing
+============
+
+Create an asymmetric KMS key with usage ``SIGN_VERIFY`` and spec ``RSA_2048``
+(Developer ID certificates use RSA keys), issue a CSR from it, and have Apple
+issue a certificate for the key. Then:
+
+.. code-block:: bash
+
+    rcodesign sign \
+        --aws-kms-key arn:aws:kms:us-east-1:123456789012:key/aaaa-bbbb \
+        --aws-kms-certificate-file developer_id.pem \
+        path/to/input path/to/output
+
+The certificate's public key is validated against the KMS key's public key
+(via ``GetPublicKey``) before any signing occurs.
+
+ECDSA P-256 (``ECC_NIST_P256``) keys are also supported. RSA signatures use
+``RSASSA_PKCS1_V1_5_SHA_256``; ECDSA signatures use ``ECDSA_SHA_256``.
+
+The corresponding config file section is:
+
+.. code-block:: toml
+
+    [sign.aws_kms]
+    key_id = "arn:aws:kms:us-east-1:123456789012:key/aaaa-bbbb"
+    certificate_file = "developer_id.pem"
+    region = "us-east-1"
+
+Notarization
+============
+
+The App Store Connect API private key (an ECDSA P-256 key used to sign
+``ES256`` JWTs) can also be held in KMS. Import the ``.p8`` key material
+into a KMS ``ECC_NIST_P256`` signing key (or create a fresh key and register
+its public key with Apple), then encode a unified API key file that
+references KMS instead of embedding the private key:
+
+.. code-block:: bash
+
+    rcodesign encode-app-store-connect-api-key \
+        --aws-kms-key arn:aws:kms:us-east-1:123456789012:key/cccc-dddd \
+        -o api_key.json \
+        <issuer-id> <key-id>
+
+The resulting ``api_key.json`` contains no secret material and can be
+committed to a repository. ``rcodesign notary-submit --api-key-file
+api_key.json ...`` works as usual, minting JWTs via KMS.

--- a/apple-codesign/src/aws_kms.rs
+++ b/apple-codesign/src/aws_kms.rs
@@ -1,0 +1,308 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! AWS KMS signing support.
+//!
+//! This module implements a signing key backend where the private key
+//! material lives in AWS KMS and never leaves it. Signing operations are
+//! performed remotely via the KMS `Sign` API.
+//!
+//! Credentials are resolved through the standard AWS SDK default provider
+//! chain. This includes static credentials in the environment, shared
+//! config/credentials files, IMDS, and - most useful for CI - web identity
+//! federation via the `AWS_WEB_IDENTITY_TOKEN_FILE` / `AWS_ROLE_ARN`
+//! environment variables (OIDC).
+
+use {
+    crate::{
+        cryptography::PrivateKey,
+        remote_signing::{session_negotiation::PublicKeyPeerDecrypt, RemoteSignError},
+        AppleCodesignError,
+    },
+    aws_sdk_kms::{
+        error::DisplayErrorContext,
+        primitives::Blob,
+        types::{KeySpec, MessageType, SigningAlgorithmSpec},
+    },
+    bytes::Bytes,
+    der::Decode,
+    log::{info, warn},
+    signature::Signer,
+    spki::EncodePublicKey,
+    std::sync::Arc,
+    x509_certificate::{
+        CapturedX509Certificate, DigestAlgorithm, EcdsaCurve, KeyAlgorithm, KeyInfoSigner, Sign,
+        Signature, SignatureAlgorithm, X509CertificateError,
+    },
+    zeroize::Zeroizing,
+};
+
+/// A signing key backed by AWS KMS.
+///
+/// The instance pairs a KMS asymmetric signing key (identified by key ID,
+/// key ARN, or alias) with an optional X.509 certificate whose subject
+/// public key is the public half of the KMS key. Without a certificate,
+/// the instance can still be used for operations that only require the
+/// key pair, like generating a certificate signing request.
+#[derive(Clone)]
+pub struct AwsKmsPrivateKey {
+    key_id: String,
+    key_algorithm: KeyAlgorithm,
+    public_key_data: Bytes,
+    certificate: Option<CapturedX509Certificate>,
+    client: aws_sdk_kms::Client,
+    rt: Arc<tokio::runtime::Runtime>,
+}
+
+impl AwsKmsPrivateKey {
+    /// Construct a new instance from a KMS key identifier and an optional
+    /// paired certificate.
+    ///
+    /// `region`, if given, overrides the region from the environment / profile.
+    ///
+    /// This calls the KMS `GetPublicKey` API to determine the key algorithm
+    /// and, when a certificate is given, validate that its public key
+    /// matches the KMS key. Construction therefore requires valid AWS
+    /// credentials with `kms:GetPublicKey` permission on the key.
+    pub fn new(
+        key_id: String,
+        certificate: Option<CapturedX509Certificate>,
+        region: Option<String>,
+    ) -> Result<Self, AppleCodesignError> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let mut loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+        if let Some(region) = region {
+            loader = loader.region(aws_sdk_kms::config::Region::new(region));
+        }
+
+        let config = rt.block_on(loader.load());
+        let client = aws_sdk_kms::Client::new(&config);
+
+        info!("retrieving public key for AWS KMS key {key_id}");
+
+        let response = rt
+            .block_on(client.get_public_key().key_id(&key_id).send())
+            .map_err(|e| {
+                AppleCodesignError::AwsKms(format!(
+                    "GetPublicKey failed for key {}: {}",
+                    key_id,
+                    DisplayErrorContext(&e)
+                ))
+            })?;
+
+        let kms_spki = response
+            .public_key()
+            .ok_or_else(|| {
+                AppleCodesignError::AwsKms("KMS GetPublicKey response missing public key".into())
+            })?
+            .as_ref()
+            .to_vec();
+
+        let key_algorithm = match response.key_spec() {
+            Some(KeySpec::Rsa2048) | Some(KeySpec::Rsa3072) | Some(KeySpec::Rsa4096) => {
+                KeyAlgorithm::Rsa
+            }
+            Some(KeySpec::EccNistP256) => KeyAlgorithm::Ecdsa(EcdsaCurve::Secp256r1),
+            Some(KeySpec::EccNistP384) => KeyAlgorithm::Ecdsa(EcdsaCurve::Secp384r1),
+            spec => {
+                return Err(AppleCodesignError::AwsKms(format!(
+                    "unsupported KMS key spec for signing: {spec:?}"
+                )))
+            }
+        };
+
+        // The raw public key data (SPKI subjectPublicKey contents).
+        let spki = spki::SubjectPublicKeyInfoOwned::from_der(&kms_spki).map_err(|e| {
+            AppleCodesignError::AwsKms(format!("failed to parse KMS public key SPKI: {e}"))
+        })?;
+        let public_key_data = Bytes::copy_from_slice(spki.subject_public_key.raw_bytes());
+
+        if let Some(cert) = &certificate {
+            let cert_spki = cert
+                .to_public_key_der()
+                .map_err(|e| {
+                    AppleCodesignError::AwsKms(format!(
+                        "failed to encode certificate public key: {e}"
+                    ))
+                })?
+                .as_ref()
+                .to_vec();
+
+            if kms_spki != cert_spki {
+                return Err(AppleCodesignError::AwsKms(format!(
+                    "certificate public key does not match public key of KMS key {key_id}; \
+                     refusing to sign (was the certificate issued for a different key?)"
+                )));
+            }
+
+            info!("certificate public key matches KMS key");
+        }
+
+        Ok(Self {
+            key_id,
+            key_algorithm,
+            public_key_data,
+            certificate,
+            client,
+            rt: Arc::new(rt),
+        })
+    }
+
+    /// Resolve the KMS signing algorithm to use based on the key algorithm.
+    fn signing_algorithm_spec(&self) -> Result<SigningAlgorithmSpec, AppleCodesignError> {
+        match self.key_algorithm {
+            KeyAlgorithm::Rsa => Ok(SigningAlgorithmSpec::RsassaPkcs1V15Sha256),
+            KeyAlgorithm::Ecdsa(_) => Ok(SigningAlgorithmSpec::EcdsaSha256),
+            algorithm => Err(AppleCodesignError::AwsKms(format!(
+                "unsupported key algorithm for AWS KMS signing: {algorithm:?}"
+            ))),
+        }
+    }
+
+    /// Sign a pre-computed SHA-256 digest with the KMS key.
+    fn kms_sign_digest(
+        &self,
+        digest: Vec<u8>,
+        algorithm: SigningAlgorithmSpec,
+    ) -> Result<Vec<u8>, AppleCodesignError> {
+        info!(
+            "signing {} byte digest with AWS KMS key {} using {:?}",
+            digest.len(),
+            self.key_id,
+            algorithm
+        );
+
+        let response = self
+            .rt
+            .block_on(
+                self.client
+                    .sign()
+                    .key_id(&self.key_id)
+                    .message(Blob::new(digest))
+                    .message_type(MessageType::Digest)
+                    .signing_algorithm(algorithm)
+                    .send(),
+            )
+            .map_err(|e| {
+                AppleCodesignError::AwsKms(format!(
+                    "Sign failed for key {}: {}",
+                    self.key_id,
+                    DisplayErrorContext(&e)
+                ))
+            })?;
+
+        Ok(response
+            .signature()
+            .ok_or_else(|| {
+                AppleCodesignError::AwsKms("KMS Sign response missing signature".into())
+            })?
+            .as_ref()
+            .to_vec())
+    }
+
+    /// Sign an arbitrary message by hashing it locally and signing the digest in KMS.
+    fn sign_message(&self, message: &[u8]) -> Result<Vec<u8>, AppleCodesignError> {
+        let algorithm = self.signing_algorithm_spec()?;
+        let digest = DigestAlgorithm::Sha256.digest_data(message);
+
+        // For RSASSA_PKCS1_V1_5_SHA_256 with MessageType=DIGEST, KMS performs
+        // the EMSA-PKCS1-v1_5 encoding (including the DigestInfo) itself.
+        // For ECDSA_SHA_256, KMS returns an ASN.1 DER-encoded signature, which
+        // is the encoding expected everywhere in this crate.
+        self.kms_sign_digest(digest, algorithm)
+    }
+
+    /// The X.509 certificate paired with the KMS key, if any.
+    pub fn certificate(&self) -> Option<&CapturedX509Certificate> {
+        self.certificate.as_ref()
+    }
+
+    /// The KMS key ID, key ARN, or alias this signing key uses.
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+}
+
+impl Signer<Signature> for AwsKmsPrivateKey {
+    fn try_sign(&self, message: &[u8]) -> Result<Signature, signature::Error> {
+        let signature = self
+            .sign_message(message)
+            .map_err(signature::Error::from_source)?;
+
+        Ok(Signature::from(signature))
+    }
+}
+
+impl KeyInfoSigner for AwsKmsPrivateKey {}
+
+impl Sign for AwsKmsPrivateKey {
+    fn sign(&self, message: &[u8]) -> Result<(Vec<u8>, SignatureAlgorithm), X509CertificateError> {
+        let algorithm = self.signature_algorithm()?;
+
+        let signature = self
+            .sign_message(message)
+            .map_err(|e| X509CertificateError::Other(format!("AWS KMS signing error: {e}")))?;
+
+        Ok((signature, algorithm))
+    }
+
+    fn key_algorithm(&self) -> Option<KeyAlgorithm> {
+        Some(self.key_algorithm)
+    }
+
+    fn public_key_data(&self) -> Bytes {
+        self.public_key_data.clone()
+    }
+
+    fn signature_algorithm(&self) -> Result<SignatureAlgorithm, X509CertificateError> {
+        match self.key_algorithm {
+            KeyAlgorithm::Rsa => Ok(SignatureAlgorithm::RsaSha256),
+            KeyAlgorithm::Ecdsa(_) => Ok(SignatureAlgorithm::EcdsaSha256),
+            algorithm => Err(X509CertificateError::UnknownSignatureAlgorithm(format!(
+                "unsupported key algorithm for AWS KMS signing: {algorithm:?}"
+            ))),
+        }
+    }
+
+    fn private_key_data(&self) -> Option<Zeroizing<Vec<u8>>> {
+        // KMS never exposes private key material.
+        None
+    }
+
+    fn rsa_primes(
+        &self,
+    ) -> Result<Option<(Zeroizing<Vec<u8>>, Zeroizing<Vec<u8>>)>, X509CertificateError> {
+        // KMS never exposes private key material.
+        Ok(None)
+    }
+}
+
+impl PublicKeyPeerDecrypt for AwsKmsPrivateKey {
+    fn decrypt(&self, _ciphertext: &[u8]) -> Result<Vec<u8>, RemoteSignError> {
+        warn!("AWS KMS signing keys cannot be used for remote signing session decryption");
+
+        Err(RemoteSignError::Crypto(
+            "decryption via AWS KMS signing keys is not supported".into(),
+        ))
+    }
+}
+
+impl PrivateKey for AwsKmsPrivateKey {
+    fn as_key_info_signer(&self) -> &dyn KeyInfoSigner {
+        self
+    }
+
+    fn to_public_key_peer_decrypt(
+        &self,
+    ) -> Result<Box<dyn PublicKeyPeerDecrypt>, AppleCodesignError> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn finish(&self) -> Result<(), AppleCodesignError> {
+        Ok(())
+    }
+}

--- a/apple-codesign/src/cli/certificate_source.rs
+++ b/apple-codesign/src/cli/certificate_source.rs
@@ -34,6 +34,9 @@ use {
     cryptoki::context::{CInitializeArgs, CInitializeFlags, Pkcs11},
 };
 
+#[cfg(feature = "aws-kms")]
+use crate::aws_kms::AwsKmsPrivateKey;
+
 #[cfg(target_os = "macos")]
 use crate::macos::{keychain_find_code_signing_certificates, KeychainDomain};
 
@@ -645,6 +648,10 @@ pub struct CertificateSource {
     pub pkcs11_key: Option<Pkcs11SigningKey>,
 
     #[command(flatten)]
+    #[serde(default, rename = "aws_kms", skip_serializing_if = "Option::is_none")]
+    pub aws_kms_key: Option<AwsKmsSigningKey>,
+
+    #[command(flatten)]
     #[serde(default, rename = "remote", skip_serializing_if = "Option::is_none")]
     pub remote_signing_key: Option<RemoteSigningKey>,
 
@@ -688,6 +695,10 @@ impl CertificateSource {
             res.push(key as &dyn KeySource);
         }
 
+        if let Some(key) = &self.aws_kms_key {
+            res.push(key as &dyn KeySource);
+        }
+
         if let Some(key) = &self.remote_signing_key {
             res.push(key as &dyn KeySource);
         }
@@ -716,6 +727,90 @@ impl CertificateSource {
         }
 
         Ok(res)
+    }
+}
+
+#[derive(Args, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AwsKmsSigningKey {
+    /// AWS KMS key ID, key ARN, or alias ARN of an asymmetric signing key
+    #[arg(
+        id = "aws_kms_key_id",
+        long = "aws-kms-key",
+        value_name = "KEY ID OR ARN"
+    )]
+    pub key_id: Option<String>,
+
+    /// Path to file containing the X.509 certificate (PEM or DER) paired with the KMS key
+    #[arg(
+        id = "aws_kms_certificate_file",
+        long = "aws-kms-certificate-file",
+        value_name = "PATH"
+    )]
+    pub certificate_file: Option<PathBuf>,
+
+    /// AWS region the KMS key resides in (overrides environment / profile)
+    #[arg(id = "aws_kms_region", long = "aws-kms-region", value_name = "REGION")]
+    pub region: Option<String>,
+}
+
+impl KeySource for AwsKmsSigningKey {
+    #[cfg(feature = "aws-kms")]
+    fn resolve_certificates(&self) -> Result<SigningCertificates, AppleCodesignError> {
+        let key_id = match &self.key_id {
+            Some(key_id) => key_id.clone(),
+            None => return Ok(Default::default()),
+        };
+
+        // The certificate is optional: operations like CSR generation only
+        // require the key pair. Signing operations will error later if no
+        // certificate is registered.
+        let cert = if let Some(cert_file) = &self.certificate_file {
+            let cert_data = std::fs::read(cert_file)?;
+
+            // Accept either PEM or DER certificate data.
+            let cert = if let Ok(pem) = pem::parse(&cert_data) {
+                if pem.tag() != "CERTIFICATE" {
+                    return Err(AppleCodesignError::AwsKms(format!(
+                        "PEM file {} has tag '{}' but expected 'CERTIFICATE'",
+                        cert_file.display(),
+                        pem.tag()
+                    )));
+                }
+
+                CapturedX509Certificate::from_der(pem.contents())?
+            } else {
+                CapturedX509Certificate::from_der(cert_data)?
+            };
+
+            info!(
+                "loaded certificate: {}",
+                cert.subject_common_name()
+                    .unwrap_or_else(|| "unknown".into())
+            );
+
+            Some(cert)
+        } else {
+            None
+        };
+
+        let key = AwsKmsPrivateKey::new(key_id, cert.clone(), self.region.clone())?;
+
+        warn!("using AWS KMS key {}", key.key_id());
+
+        Ok(SigningCertificates {
+            keys: vec![Box::new(key)],
+            certs: cert.into_iter().collect(),
+        })
+    }
+
+    #[cfg(not(feature = "aws-kms"))]
+    fn resolve_certificates(&self) -> Result<SigningCertificates, AppleCodesignError> {
+        if self.key_id.is_some() {
+            error!("AWS KMS support not available; ignoring --aws-kms-* arguments");
+        }
+
+        Ok(Default::default())
     }
 }
 

--- a/apple-codesign/src/cli/mod.rs
+++ b/apple-codesign/src/cli/mod.rs
@@ -425,17 +425,42 @@ struct EncodeAppStoreConnectApiKey {
     key_id: String,
 
     /// Path to a file containing the private key downloaded from Apple
-    private_key_path: PathBuf,
+    #[arg(required_unless_present = "aws_kms_key")]
+    private_key_path: Option<PathBuf>,
+
+    /// AWS KMS key ID, key ARN, or alias ARN holding the private key
+    ///
+    /// Use this instead of a private key path when the App Store Connect
+    /// API private key has been imported into AWS KMS. The resulting JSON
+    /// file contains no secret material.
+    #[arg(long, conflicts_with = "private_key_path", value_name = "KEY ID OR ARN")]
+    aws_kms_key: Option<String>,
+
+    /// AWS region of the KMS key (overrides environment / profile)
+    #[arg(long, requires = "aws_kms_key", value_name = "REGION")]
+    aws_kms_region: Option<String>,
 }
 
 #[cfg(feature = "notarize")]
 impl CliCommand for EncodeAppStoreConnectApiKey {
     fn run(&self, _context: &Context) -> Result<(), AppleCodesignError> {
-        let unified = app_store_connect::UnifiedApiKey::from_ecdsa_pem_path(
-            &self.issuer_id,
-            &self.key_id,
-            &self.private_key_path,
-        )?;
+        let unified = if let Some(kms_key) = &self.aws_kms_key {
+            app_store_connect::UnifiedApiKey::from_aws_kms_key(
+                &self.issuer_id,
+                &self.key_id,
+                kms_key,
+                self.aws_kms_region.clone(),
+            )
+        } else if let Some(private_key_path) = &self.private_key_path {
+            app_store_connect::UnifiedApiKey::from_ecdsa_pem_path(
+                &self.issuer_id,
+                &self.key_id,
+                private_key_path,
+            )?
+        } else {
+            // clap requires one of the two key sources to be present.
+            return Err(AppleCodesignError::CliBadArgument);
+        };
 
         if let Some(output_path) = &self.output_path {
             eprintln!("writing unified key JSON to {}", output_path.display());

--- a/apple-codesign/src/error.rs
+++ b/apple-codesign/src/error.rs
@@ -371,6 +371,9 @@ pub enum AppleCodesignError {
     #[error("PKCS11 error: {0}")]
     Pkcs11Error(String),
 
+    #[error("AWS KMS error: {0}")]
+    AwsKms(String),
+
     #[error("remote signing error: {0}")]
     RemoteSign(#[from] RemoteSignError),
 

--- a/apple-codesign/src/lib.rs
+++ b/apple-codesign/src/lib.rs
@@ -170,3 +170,6 @@ pub mod yubikey;
 
 #[cfg(feature = "pkcs11")]
 pub mod pkcs11;
+
+#[cfg(feature = "aws-kms")]
+pub mod aws_kms;

--- a/apple-codesign/tests/cmd/analyze-certificate.trycmd
+++ b/apple-codesign/tests/cmd/analyze-certificate.trycmd
@@ -89,6 +89,15 @@ Options:
       --pkcs11-key-id <ID>
           Private key ID in PKCS11 token (CKA_ID attribute)
 
+      --aws-kms-key <KEY ID OR ARN>
+          AWS KMS key ID, key ARN, or alias ARN of an asymmetric signing key
+
+      --aws-kms-certificate-file <PATH>
+          Path to file containing the X.509 certificate (PEM or DER) paired with the KMS key
+
+      --aws-kms-region <REGION>
+          AWS region the KMS key resides in (overrides environment / profile)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/encode-app-store-connect-api-key.trycmd
+++ b/apple-codesign/tests/cmd/encode-app-store-connect-api-key.trycmd
@@ -31,7 +31,7 @@ to the file. However, file access restrictions may not be as secure as you
 want. Security conscious individuals should audit the permissions of the
 file and adjust accordingly.
 
-Usage: rcodesign[EXE] encode-app-store-connect-api-key [OPTIONS] <ISSUER_ID> <KEY_ID> <PRIVATE_KEY_PATH>
+Usage: rcodesign[EXE] encode-app-store-connect-api-key [OPTIONS] <ISSUER_ID> <KEY_ID> [PRIVATE_KEY_PATH]
 
 Arguments:
   <ISSUER_ID>
@@ -40,7 +40,7 @@ Arguments:
   <KEY_ID>
           The Key ID. A short alphanumeric string like DEADBEEF42
 
-  <PRIVATE_KEY_PATH>
+  [PRIVATE_KEY_PATH]
           Path to a file containing the private key downloaded from Apple
 
 Options:
@@ -56,10 +56,18 @@ Options:
   -o, --output-path <OUTPUT_PATH>
           Path to a JSON file to create the output to
 
+      --aws-kms-key <KEY ID OR ARN>
+          AWS KMS key ID, key ARN, or alias ARN holding the private key
+          
+          Use this instead of a private key path when the App Store Connect API private key has been imported into AWS KMS. The resulting JSON file contains no secret material.
+
   -P, --profile <PROFILE>
           Configuration profile to load.
           
           If not specified, the implicit "default" profile is loaded.
+
+      --aws-kms-region <REGION>
+          AWS region of the KMS key (overrides environment / profile)
 
   -v, --verbose...
           Increase logging verbosity. Can be specified multiple times

--- a/apple-codesign/tests/cmd/generate-csr.trycmd
+++ b/apple-codesign/tests/cmd/generate-csr.trycmd
@@ -88,6 +88,15 @@ Options:
       --pkcs11-key-id <ID>
           Private key ID in PKCS11 token (CKA_ID attribute)
 
+      --aws-kms-key <KEY ID OR ARN>
+          AWS KMS key ID, key ARN, or alias ARN of an asymmetric signing key
+
+      --aws-kms-certificate-file <PATH>
+          Path to file containing the X.509 certificate (PEM or DER) paired with the KMS key
+
+      --aws-kms-region <REGION>
+          AWS region the KMS key resides in (overrides environment / profile)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/remote-sign.trycmd
+++ b/apple-codesign/tests/cmd/remote-sign.trycmd
@@ -95,6 +95,15 @@ Options:
       --pkcs11-key-id <ID>
           Private key ID in PKCS11 token (CKA_ID attribute)
 
+      --aws-kms-key <KEY ID OR ARN>
+          AWS KMS key ID, key ARN, or alias ARN of an asymmetric signing key
+
+      --aws-kms-certificate-file <PATH>
+          Path to file containing the X.509 certificate (PEM or DER) paired with the KMS key
+
+      --aws-kms-region <REGION>
+          AWS region the KMS key resides in (overrides environment / profile)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/sign.trycmd
+++ b/apple-codesign/tests/cmd/sign.trycmd
@@ -422,6 +422,15 @@ Options:
       --pkcs11-key-id <ID>
           Private key ID in PKCS11 token (CKA_ID attribute)
 
+      --aws-kms-key <KEY ID OR ARN>
+          AWS KMS key ID, key ARN, or alias ARN of an asymmetric signing key
+
+      --aws-kms-certificate-file <PATH>
+          Path to file containing the X.509 certificate (PEM or DER) paired with the KMS key
+
+      --aws-kms-region <REGION>
+          AWS region the KMS key resides in (overrides environment / profile)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 

--- a/apple-codesign/tests/cmd/smartcard-import.trycmd
+++ b/apple-codesign/tests/cmd/smartcard-import.trycmd
@@ -91,6 +91,15 @@ Options:
       --pkcs11-key-id <ID>
           Private key ID in PKCS11 token (CKA_ID attribute)
 
+      --aws-kms-key <KEY ID OR ARN>
+          AWS KMS key ID, key ARN, or alias ARN of an asymmetric signing key
+
+      --aws-kms-certificate-file <PATH>
+          Path to file containing the X.509 certificate (PEM or DER) paired with the KMS key
+
+      --aws-kms-region <REGION>
+          AWS region the KMS key resides in (overrides environment / profile)
+
       --remote-signing-url <URL>
           URL of a remote code signing server
 


### PR DESCRIPTION
This adds explicit support for keeping both the code signing certificate and the notarization private key in AWS KMS for more secure storage of credentials in CI workloads. We are using this feature in the new JuliaLang (https://github.com/JuliaLang/julia) CI pipeline (https://github.com/JuliaCI/julia-buildkite/pull/544) after experiencing a credential compromise in our previous setup.

AI Disclosure: Entirely written by Claude. Appears to be working well, but as with #321, I am not particularly qualified to judge implementation quality as I am not a Rust programmer nor familiar with this code base.