### PR TITLE
apple-codesign: add --smartcard-serial device selection; fix --smartcard-pin-env dropped in sign path

### DIFF
--- a/apple-codesign/src/cli/certificate_source.rs
+++ b/apple-codesign/src/cli/certificate_source.rs
@@ -150,10 +150,9 @@ pub struct SmartcardSigningKey {
     pub pin: Option<String>,
 
     /// Environment variable holding the smartcard PIN
-    ///
-    /// (Not `serde(skip)`: commands like `sign` round-trip this struct
-    /// through the config layer, and skipping silently dropped the value,
-    /// causing an interactive PIN prompt despite the argument.)
+    // Not `serde(skip)`: commands like `sign` round-trip this struct
+    // through the config layer, and skipping silently dropped the value,
+    // causing an interactive PIN prompt despite --smartcard-pin-env.
     #[arg(long = "smartcard-pin-env", value_name = "STRING")]
     pub pin_env: Option<String>,
 

--- a/apple-codesign/src/cli/certificate_source.rs
+++ b/apple-codesign/src/cli/certificate_source.rs
@@ -150,9 +150,18 @@ pub struct SmartcardSigningKey {
     pub pin: Option<String>,
 
     /// Environment variable holding the smartcard PIN
+    ///
+    /// (Not `serde(skip)`: commands like `sign` round-trip this struct
+    /// through the config layer, and skipping silently dropped the value,
+    /// causing an interactive PIN prompt despite the argument.)
     #[arg(long = "smartcard-pin-env", value_name = "STRING")]
-    #[serde(skip)]
     pub pin_env: Option<String>,
+
+    /// Serial number of the smartcard device to use
+    ///
+    /// Required to select a device when multiple smartcards are connected.
+    #[arg(long = "smartcard-serial", value_name = "SERIAL")]
+    pub serial: Option<u32>,
 }
 
 impl KeySource for SmartcardSigningKey {
@@ -161,7 +170,7 @@ impl KeySource for SmartcardSigningKey {
         if let Some(slot) = &self.slot {
             let slot_id = ::yubikey::piv::SlotId::from_str(slot)?;
             let formatted = hex::encode([u8::from(slot_id)]);
-            let mut yk = YubiKey::new()?;
+            let mut yk = YubiKey::new_with_serial(self.serial)?;
 
             if let Some(pin) = &self.pin {
                 let pin = pin.clone();

--- a/apple-codesign/src/cli/config.rs
+++ b/apple-codesign/src/cli/config.rs
@@ -193,6 +193,7 @@ mod test {
                     slot: Some("9c".into()),
                     pin: None,
                     pin_env: None,
+                    serial: None,
                 }),
                 ..Default::default()
             }
@@ -214,6 +215,7 @@ mod test {
                     slot: Some("9c".into()),
                     pin: Some("1234".into()),
                     pin_env: None,
+                    serial: None,
                 }),
                 ..Default::default()
             }

--- a/apple-codesign/src/cli/mod.rs
+++ b/apple-codesign/src/cli/mod.rs
@@ -1636,6 +1636,12 @@ struct SmartcardGenerateKey {
     #[arg(long)]
     smartcard_slot: String,
 
+    /// Serial number of the smartcard device to use
+    ///
+    /// Required to select a device when multiple smartcards are connected.
+    #[arg(long)]
+    smartcard_serial: Option<u32>,
+
     #[command(flatten)]
     policy: YubikeyPolicy,
 }
@@ -1648,7 +1654,7 @@ impl CliCommand for SmartcardGenerateKey {
         let touch_policy = str_to_touch_policy(self.policy.touch_policy.as_str())?;
         let pin_policy = str_to_pin_policy(self.policy.pin_policy.as_str())?;
 
-        let mut yk = YubiKey::new()?;
+        let mut yk = YubiKey::new_with_serial(self.smartcard_serial)?;
         yk.set_pin_callback(prompt_smartcard_pin);
 
         yk.generate_key(slot_id, touch_policy, pin_policy)?;
@@ -1740,7 +1746,12 @@ impl CliCommand for SmartcardImport {
         );
         print_certificate_info(&cert)?;
 
-        let mut yk = YubiKey::new()?;
+        let mut yk = YubiKey::new_with_serial(
+            self.certificate
+                .smartcard_key
+                .as_ref()
+                .and_then(|key| key.serial),
+        )?;
         yk.set_pin_callback(prompt_smartcard_pin);
 
         if self.dry_run {

--- a/apple-codesign/src/yubikey.rs
+++ b/apple-codesign/src/yubikey.rs
@@ -185,7 +185,20 @@ impl From<RawYubiKey> for YubiKey {
 impl YubiKey {
     /// Construct a new instance.
     pub fn new() -> Result<Self, AppleCodesignError> {
-        let yk = RawYubiKey::open()?;
+        Self::new_with_serial(None)
+    }
+
+    /// Construct a new instance, optionally selecting a specific device by
+    /// its serial number.
+    ///
+    /// A serial number is required to disambiguate when multiple YubiKeys
+    /// are connected: [RawYubiKey::open] refuses to choose among several
+    /// devices.
+    pub fn new_with_serial(serial: Option<u32>) -> Result<Self, AppleCodesignError> {
+        let yk = match serial {
+            Some(serial) => RawYubiKey::open_by_serial(Serial::from(serial))?,
+            None => RawYubiKey::open()?,
+        };
         let serial = yk.serial();
         let yk = Arc::new(Mutex::new(yk));
 

--- a/apple-codesign/tests/cmd/analyze-certificate.trycmd
+++ b/apple-codesign/tests/cmd/analyze-certificate.trycmd
@@ -37,6 +37,11 @@ Options:
   -v, --verbose...
           Increase logging verbosity. Can be specified multiple times
 
+      --smartcard-serial <SERIAL>
+          Serial number of the smartcard device to use
+          
+          Required to select a device when multiple smartcards are connected.
+
       --keychain-domain <DOMAIN>
           (macOS only) Keychain domain to operate on
           

--- a/apple-codesign/tests/cmd/generate-csr.trycmd
+++ b/apple-codesign/tests/cmd/generate-csr.trycmd
@@ -36,6 +36,11 @@ Options:
       --smartcard-pin-env <STRING>
           Environment variable holding the smartcard PIN
 
+      --smartcard-serial <SERIAL>
+          Serial number of the smartcard device to use
+          
+          Required to select a device when multiple smartcards are connected.
+
       --keychain-domain <DOMAIN>
           (macOS only) Keychain domain to operate on
           

--- a/apple-codesign/tests/cmd/remote-sign.trycmd
+++ b/apple-codesign/tests/cmd/remote-sign.trycmd
@@ -43,6 +43,11 @@ Options:
       --smartcard-pin-env <STRING>
           Environment variable holding the smartcard PIN
 
+      --smartcard-serial <SERIAL>
+          Serial number of the smartcard device to use
+          
+          Required to select a device when multiple smartcards are connected.
+
       --keychain-domain <DOMAIN>
           (macOS only) Keychain domain to operate on
           

--- a/apple-codesign/tests/cmd/sign.trycmd
+++ b/apple-codesign/tests/cmd/sign.trycmd
@@ -370,6 +370,11 @@ Options:
       --smartcard-pin-env <STRING>
           Environment variable holding the smartcard PIN
 
+      --smartcard-serial <SERIAL>
+          Serial number of the smartcard device to use
+          
+          Required to select a device when multiple smartcards are connected.
+
       --keychain-domain <DOMAIN>
           (macOS only) Keychain domain to operate on
           

--- a/apple-codesign/tests/cmd/smartcard-generate-key.trycmd
+++ b/apple-codesign/tests/cmd/smartcard-generate-key.trycmd
@@ -22,20 +22,25 @@ Options:
           
           If not specified, the implicit "default" profile is loaded.
 
+      --smartcard-serial <SMARTCARD_SERIAL>
+          Serial number of the smartcard device to use
+          
+          Required to select a device when multiple smartcards are connected.
+
       --touch-policy <TOUCH_POLICY>
           Smartcard touch policy to protect key access
           
           [default: default]
           [possible values: default, always, never, cached]
 
+  -v, --verbose...
+          Increase logging verbosity. Can be specified multiple times
+
       --pin-policy <PIN_POLICY>
           Smartcard pin prompt policy to protect key access
           
           [default: default]
           [possible values: default, never, once, always]
-
-  -v, --verbose...
-          Increase logging verbosity. Can be specified multiple times
 
   -h, --help
           Print help (see a summary with '-h')

--- a/apple-codesign/tests/cmd/smartcard-import.trycmd
+++ b/apple-codesign/tests/cmd/smartcard-import.trycmd
@@ -39,6 +39,11 @@ Options:
       --smartcard-pin-env <STRING>
           Environment variable holding the smartcard PIN
 
+      --smartcard-serial <SERIAL>
+          Serial number of the smartcard device to use
+          
+          Required to select a device when multiple smartcards are connected.
+
       --keychain-domain <DOMAIN>
           (macOS only) Keychain domain to operate on
           


### PR DESCRIPTION
## Motivation

YubiKey::new() calls the yubikey crate's open(), which refuses to operate when more than one YubiKey is connected ('multiple YubiKeys detected!'). Any workflow with several tokens attached to one host (build farms, multi-identity signing hosts) currently cannot use rcodesign at all.

## Changes

- New --smartcard-serial argument on the certificate source (sign, generate-csr, etc.) plus smartcard-generate-key and smartcard-import, mapped to the yubikey crate's open_by_serial. Without the argument, behavior is unchanged.
- Fixes #353: remove #[serde(skip)] from pin_env. The sign command round-trips CertificateSource through the config layer, which silently dropped the env var name and caused an interactive PIN prompt despite --smartcard-pin-env being given.
- Regenerated trycmd help snapshots; fixed config.rs test struct literals for the new field.

## Testing

Validated on real hardware (two YubiKey 5C, firmware 5.7.4, macOS 26.6, Apple-issued certs):
- Two devices connected: unpatched build fails; with --smartcard-serial each device signs with its own identity (verified via codesign --verify --strict + TeamIdentifier), no cross-talk.
- Nonexistent serial: clean 'YubiKey error: not found' - no fallback to a present device.
- --smartcard-pin-env on a PIN-gated slot: 'using PIN from ... environment variable' -> pin verification successful -> valid signature, fully non-interactive.
- cargo test -p apple-codesign passes.